### PR TITLE
Implement 'interruptible' election setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![[CI] Lint](https://github.com/decidim-vocdoni/decidim-module-vocdoni/actions/workflows/lint.yml/badge.svg)](https://github.com/decidim-vocdoni/decidim-module-vocdoni/actions/workflows/lint.yml)
 [![[CI] Tests](https://github.com/decidim-vocdoni/decidim-module-vocdoni/actions/workflows/test.yml/badge.svg)](https://github.com/decidim-vocdoni/decidim-module-vocdoni/actions/workflows/test.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/126b8ece66b8292802f3/maintainability)](https://codeclimate.com/github/decidim-vocdoni/decidim-module-vocdoni/maintainability)
+[![codecov](https://codecov.io/gh/decidim-vocdoni/decidim-module-vocdoni/branch/main/graph/badge.svg?token=LRT4MJBNVY)](https://codecov.io/gh/decidim-vocdoni/decidim-module-vocdoni)
 
 
 :warning: This module is under development and is not ready to be used in production.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ status are checked every 15 minutes, you can do it with this configuration:
 
 ```crontab
 # Change Elections status on decidim-vocdoni
-0/15 0 * * * cd /home/user/decidim_application && RAILS_ENV=production bin/rails decidim_vocdoni:change_election_status
+0/15 0 * * * cd /home/user/decidim_application && RAILS_ENV=production bin/rails decidim_vocdoni:change_election_status[quiet]
+```
+
+During development, if you want to see the output of the command, you can run it without the `quiet` argument:
+
+```bash
+bin/rails decidim_vocdoni:change_election_status
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -50,13 +50,7 @@ status are checked every 15 minutes, you can do it with this configuration:
 
 ```crontab
 # Change Elections status on decidim-vocdoni
-0/15 0 * * * cd /home/user/decidim_application && RAILS_ENV=production bin/rails decidim_vocdoni:change_election_status[quiet]
-```
-
-During development, if you want to see the output of the command, you can run it without the `quiet` argument:
-
-```bash
-bin/rails decidim_vocdoni:change_election_status
+0/15 0 * * * cd /home/user/decidim_application && RAILS_ENV=production bin/rails decidim_vocdoni:change_election_status > /dev/null
 ```
 
 ## Configuration

--- a/app/cells/decidim/vocdoni/election_m_cell.rb
+++ b/app/cells/decidim/vocdoni/election_m_cell.rb
@@ -61,8 +61,10 @@ module Decidim
         case model.voting_period_status
         when :ongoing
           ["success"]
-        when :upcoming
+        when [:paused, :upcoming]
           ["warning"]
+        when :canceled
+          ["alert"]
         else
           ["muted"]
         end

--- a/app/cells/decidim/vocdoni/election_preview/show.erb
+++ b/app/cells/decidim/vocdoni/election_preview/show.erb
@@ -4,7 +4,7 @@
 
     <p><%= t("decidim.vocdoni.elections.preview.description") %></p>
 
-    <ul class="accordion mb-m evote__preview"
+    <ul class="voc-accordion accordion mb-m evote__preview"
       data-accordion
       data-multi-expand="true"
       data-allow-all-closed="true">

--- a/app/cells/decidim/vocdoni/election_results/show.erb
+++ b/app/cells/decidim/vocdoni/election_results/show.erb
@@ -4,7 +4,7 @@
 
     <p><%= t("decidim.vocdoni.elections.results.description") %></p>
 
-    <ul class="accordion mb-m evote__preview"
+    <ul class="voc-accordion accordion mb-m evote__preview"
       data-accordion
       data-multi-expand="true"
       data-allow-all-closed="true">

--- a/app/cells/decidim/vocdoni/election_vote_cta/show.erb
+++ b/app/cells/decidim/vocdoni/election_vote_cta/show.erb
@@ -3,7 +3,16 @@
 <% end %>
 
 <div>
-  <% if model.ongoing? %>
+  <% if model.canceled? %>
+    <div class="callout alert">
+      <%= t("canceled", scope: "decidim.vocdoni.elections.show") %>
+    </div>
+  <% elsif model.paused? %>
+    <div class="callout warning">
+      <%= t("paused", scope: "decidim.vocdoni.elections.show") %>
+    </div>
+    <span class="button button--sc disabled"><%= t("action_button.vote", scope: "decidim.vocdoni.elections.show") %></span>
+  <% elsif model.ongoing? %>
     <%= link_to new_election_vote_path, resource: model, class: "button button--sc" do %>
       <%= vote_action_button_text %>
     <% end %>

--- a/app/commands/decidim/vocdoni/admin/create_answer.rb
+++ b/app/commands/decidim/vocdoni/admin/create_answer.rb
@@ -28,7 +28,7 @@ module Decidim
         attr_reader :form, :answer
 
         def invalid?
-          form.election.started? || form.invalid?
+          form.election.blocked? || form.invalid?
         end
 
         def create_answer

--- a/app/commands/decidim/vocdoni/admin/create_question.rb
+++ b/app/commands/decidim/vocdoni/admin/create_question.rb
@@ -12,9 +12,12 @@ module Decidim
 
         # Creates the question if valid.
         #
-        # Broadcasts :ok if successful, :invalid otherwise.
+        # Broadcasts:
+        # * :ok if successful
+        # * :election_ongoing if the election is already blocked
+        # * :invalid otherwise.
         def call
-          return broadcast(:election_started) if form.election.started?
+          return broadcast(:election_ongoing) if form.election.blocked?
           return broadcast(:invalid) if form.invalid?
 
           create_question!

--- a/app/commands/decidim/vocdoni/admin/destroy_answer.rb
+++ b/app/commands/decidim/vocdoni/admin/destroy_answer.rb
@@ -28,7 +28,7 @@ module Decidim
         attr_reader :answer, :current_user
 
         def invalid?
-          answer.question.election.started?
+          answer.question.election.blocked?
         end
 
         def destroy_answer

--- a/app/commands/decidim/vocdoni/admin/destroy_election.rb
+++ b/app/commands/decidim/vocdoni/admin/destroy_election.rb
@@ -31,7 +31,7 @@ module Decidim
         attr_reader :election, :current_user
 
         def invalid?
-          election.started?
+          election.blocked?
         end
 
         def destroy_election!

--- a/app/commands/decidim/vocdoni/admin/destroy_question.rb
+++ b/app/commands/decidim/vocdoni/admin/destroy_question.rb
@@ -27,7 +27,7 @@ module Decidim
         attr_reader :question, :current_user
 
         def invalid?
-          question.election.started?
+          question.election.blocked?
         end
 
         def destroy_question!

--- a/app/commands/decidim/vocdoni/admin/update_answer.rb
+++ b/app/commands/decidim/vocdoni/admin/update_answer.rb
@@ -30,7 +30,7 @@ module Decidim
         attr_reader :form, :answer
 
         def invalid?
-          form.election.started? || form.invalid?
+          form.election.blocked? || form.invalid?
         end
 
         def update_answer

--- a/app/commands/decidim/vocdoni/admin/update_election_status.rb
+++ b/app/commands/decidim/vocdoni/admin/update_election_status.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Vocdoni
+    module Admin
+      # This command gets called when saving the election status from the admin panel
+      # To be used only when the election is interruptible
+      class UpdateElectionStatus < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # form - An ElectionStatusForm object with the status to update
+        def initialize(form)
+          @form = form
+        end
+
+        # Public: Update Election Status
+        #
+        # Broadcasts :ok if setup, :invalid otherwise.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          transaction do
+            change_election_status
+            log_action
+          end
+
+          broadcast(:ok, election)
+        rescue StandardError => e
+          broadcast(:invalid, e.message)
+        end
+
+        private
+
+        attr_reader :form
+
+        delegate :election, to: :form
+
+        def change_election_status
+          election.status = form.status
+          election.save!
+        end
+
+        def log_action
+          Decidim.traceability.perform_action!(
+            :change_election_status,
+            election,
+            form.current_user
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/vocdoni/admin/update_question.rb
+++ b/app/commands/decidim/vocdoni/admin/update_question.rb
@@ -27,7 +27,7 @@ module Decidim
         attr_reader :form, :question
 
         def invalid?
-          question.election.started? || form.invalid?
+          question.election.blocked? || form.invalid?
         end
 
         def update_question!

--- a/app/controllers/decidim/vocdoni/admin/answers_controller.rb
+++ b/app/controllers/decidim/vocdoni/admin/answers_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       class AnswersController < Admin::ApplicationController
         include Decidim::Proposals::Admin::Picker
         helper Decidim::ApplicationHelper
-        helper_method :election, :question, :answers, :answers
+        helper_method :election, :question, :answers, :answer
 
         def index; end
 

--- a/app/controllers/decidim/vocdoni/admin/elections_controller.rb
+++ b/app/controllers/decidim/vocdoni/admin/elections_controller.rb
@@ -98,8 +98,9 @@ module Decidim
 
           UpdateAnswersValues.call(election) do
             on(:ok) do
-              flash[:notice] = I18n.t("admin.elections.answers_values.success", scope: "decidim.vocdoni")
-              redirect_to election_steps_path(election)
+              respond_to do |format|
+                format.json { render json: { status: :ok } }
+              end
             end
           end
         end

--- a/app/controllers/decidim/vocdoni/admin/questions_controller.rb
+++ b/app/controllers/decidim/vocdoni/admin/questions_controller.rb
@@ -27,8 +27,8 @@ module Decidim
               render action: "new"
             end
 
-            on(:election_started) do
-              flash.now[:alert] = I18n.t("questions.create.election_started", scope: "decidim.vocdoni.admin")
+            on(:election_ongoing) do
+              flash.now[:alert] = I18n.t("questions.create.election_ongoing", scope: "decidim.vocdoni.admin")
               render action: "new"
             end
           end

--- a/app/controllers/decidim/vocdoni/admin/steps_controller.rb
+++ b/app/controllers/decidim/vocdoni/admin/steps_controller.rb
@@ -49,6 +49,8 @@ module Decidim
         def current_step_form_class
           @current_step_form_class ||= {
             "create_election" => SetupForm,
+            "paused" => ElectionStatusForm,
+            "vote" => ElectionStatusForm,
             "vote_ended" => ResultsForm
           }[current_step]
         end
@@ -56,6 +58,8 @@ module Decidim
         def current_step_command_class
           @current_step_command_class ||= {
             "create_election" => SetupElection,
+            "paused" => UpdateElectionStatus,
+            "vote" => UpdateElectionStatus,
             "vote_ended" => SaveResults
           }[current_step]
         end

--- a/app/forms/decidim/vocdoni/admin/election_status_form.rb
+++ b/app/forms/decidim/vocdoni/admin/election_status_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Vocdoni
+    module Admin
+      # This class holds a Form to update the status of elections from Decidim's admin panel.
+      class ElectionStatusForm < Decidim::Form
+        attribute :status, String
+
+        validates :status, inclusion: { in: %w(paused canceled vote vote_ended) }
+        validate :election_type_interruptible
+
+        delegate :election, to: :context
+
+        def current_step; end
+
+        def main_button?
+          false
+        end
+
+        private
+
+        def election_type_interruptible
+          errors.add(:election, :not_interruptible) unless context.election.election_type["interruptible"]
+        end
+      end
+    end
+  end
+end

--- a/app/forms/decidim/vocdoni/admin/setup_form.rb
+++ b/app/forms/decidim/vocdoni/admin/setup_form.rb
@@ -53,7 +53,7 @@ module Decidim
         end
 
         def time_before_minutes
-          Decidim::Vocdoni.setup_minimum_minutes_before_start
+          Decidim::Vocdoni.config.setup_minimum_minutes_before_start
         end
       end
     end

--- a/app/forms/decidim/vocdoni/admin/setup_form.rb
+++ b/app/forms/decidim/vocdoni/admin/setup_form.rb
@@ -21,7 +21,6 @@ module Decidim
           @validations ||= [
             [:minimum_questions, { link: router.election_questions_path(election) }, election.questions.any?],
             [:minimum_answers, { link: router.election_questions_path(election) }, election.minimum_answers?],
-            [:answers_have_values, { link: router.answers_values_election_path(election) }, election.answers_have_values?],
             [:published, { link: router.edit_election_path(election) }, election.published_at.present?],
             [:time_before, { link: router.edit_election_path(election), minutes: time_before_minutes }, election.minimum_minutes_before_start?],
             [:census_ready, { link: router.election_census_path(election) }, census.ready_to_setup?]

--- a/app/helpers/decidim/vocdoni/admin/steps_helper.rb
+++ b/app/helpers/decidim/vocdoni/admin/steps_helper.rb
@@ -8,13 +8,29 @@ module Decidim
       module StepsHelper
         def steps(current_step)
           step_class = "text-success"
-          (["create_election"] + Decidim::Vocdoni::Election.statuses.keys).map do |step|
+
+          status_for_step(current_step).map do |step|
             if step == current_step
               step_class = "text-muted"
               [step, "text-warning"]
             else
               [step, step_class]
             end
+          end
+        end
+
+        private
+
+        def status_for_step(current_step)
+          status = ["create_election"] + Decidim::Vocdoni::Election.statuses.keys
+
+          case current_step
+          when "paused"
+            status - ["canceled"]
+          when "canceled"
+            status - %w(paused vote_ended results_published)
+          else
+            status - %w(canceled paused)
           end
         end
       end

--- a/app/models/decidim/vocdoni/election.rb
+++ b/app/models/decidim/vocdoni/election.rb
@@ -27,14 +27,22 @@ module Decidim::Vocdoni
     #
     # Returns a boolean.
     def started?
-      start_time <= Time.current && !status.nil?
+      return false if status.nil?
+      return false if paused?
+
+      start_time <= Time.current
     end
 
     # Public: Checks if the election finished
     #
     # Returns a boolean.
     def finished?
-      end_time < Time.current && !status.nil? || canceled? || vote_ended? || results_published?
+      return false if status.nil?
+      return true if canceled?
+      return true if vote_ended?
+      return true if results_published?
+
+      end_time < Time.current
     end
 
     # Public: Checks if the election ongoing now

--- a/app/models/decidim/vocdoni/election.rb
+++ b/app/models/decidim/vocdoni/election.rb
@@ -62,7 +62,7 @@ module Decidim::Vocdoni
     #
     # Returns a boolean.
     def minimum_minutes_before_start?
-      start_time > (Time.zone.at(Decidim::Vocdoni.setup_minimum_minutes_before_start.minutes.from_now))
+      start_time > (Time.zone.at(Decidim::Vocdoni.config.setup_minimum_minutes_before_start.minutes.from_now))
     end
 
     # Public: Checks if all the Answers related to an Election (through Questions) have a value

--- a/app/models/decidim/vocdoni/election.rb
+++ b/app/models/decidim/vocdoni/election.rb
@@ -10,7 +10,7 @@ module Decidim::Vocdoni
     include Decidim::Publicable
     include Decidim::Traceable
 
-    enum status: [:created, :vote, :vote_ended, :results_published].index_with(&:to_s)
+    enum status: [:created, :vote, :paused, :vote_ended, :results_published, :canceled].index_with(&:to_s)
 
     component_manifest_name "vocdoni"
 

--- a/app/models/decidim/vocdoni/election.rb
+++ b/app/models/decidim/vocdoni/election.rb
@@ -34,7 +34,7 @@ module Decidim::Vocdoni
     #
     # Returns a boolean.
     def finished?
-      end_time < Time.current && !status.nil?
+      end_time < Time.current && !status.nil? || canceled? || vote_ended? || results_published?
     end
 
     # Public: Checks if the election ongoing now

--- a/app/models/decidim/vocdoni/election.rb
+++ b/app/models/decidim/vocdoni/election.rb
@@ -27,14 +27,14 @@ module Decidim::Vocdoni
     #
     # Returns a boolean.
     def started?
-      start_time <= Time.current
+      start_time <= Time.current && !status.nil?
     end
 
     # Public: Checks if the election finished
     #
     # Returns a boolean.
     def finished?
-      end_time < Time.current
+      end_time < Time.current && !status.nil?
     end
 
     # Public: Checks if the election ongoing now
@@ -76,7 +76,11 @@ module Decidim::Vocdoni
     #
     # Returns one of these symbols: upcoming, ongoing or finished
     def voting_period_status
-      if finished?
+      if paused?
+        :paused
+      elsif canceled?
+        :canceled
+      elsif finished?
         :finished
       elsif started?
         :ongoing

--- a/app/models/decidim/vocdoni/voter.rb
+++ b/app/models/decidim/vocdoni/voter.rb
@@ -20,7 +20,7 @@ module Decidim
       end
 
       def self.insert_all(election, values)
-        values.each { |value| create(email: value.first, election: election, born_at: value.second) }
+        values.each { |value| create(email: value.first.downcase, election: election, born_at: value.second) }
       end
 
       def self.clear(election)

--- a/app/packs/entrypoints/admin/decidim_vocdoni_admin.js
+++ b/app/packs/entrypoints/admin/decidim_vocdoni_admin.js
@@ -1,5 +1,7 @@
 import "src/decidim/vocdoni/admin/create_wallet"
 import "src/decidim/vocdoni/admin/generate_credentials"
+import "src/decidim/vocdoni/admin/available_credits"
+
 import "src/decidim/vocdoni/admin/steps/setup_election"
 import "src/decidim/vocdoni/admin/steps/vote"
 import "src/decidim/vocdoni/admin/steps/vote_ended"

--- a/app/packs/src/decidim/vocdoni/admin/available_credits.js
+++ b/app/packs/src/decidim/vocdoni/admin/available_credits.js
@@ -1,0 +1,48 @@
+import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
+
+const CREDIT_SPAN_SELECTOR = ".js-vocdoni-credits-balance";
+const NO_TOKENS_MESSAGE_SELECTOR = ".js-vocdoni-credits-collect-faucet-tokens-section";
+const COLLECT_TOKENS_BUTTON_SELECTOR = ".js-vocdoni-credits-collect-faucet-tokens";
+const CONTAINER_SELECTOR = ".process-content";
+
+const showAvailableCredits = async () => {
+  const creditsSpan = document.querySelector(CREDIT_SPAN_SELECTOR);
+  if (!creditsSpan) {
+    return;
+  }
+
+  const client = initVocdoniClient();
+  const clientInfo = await client.createAccount();
+
+  if (clientInfo.balance === 0) {
+    document.querySelector(NO_TOKENS_MESSAGE_SELECTOR).classList.remove("hide");
+    document.querySelectorAll(".js-vocdoni-interruptible").forEach((element) => {
+      element.disabled = true;
+    });
+  }
+
+  creditsSpan.innerHTML = clientInfo.balance;
+};
+
+const collectFaucetTokensListener = async () => {
+  const collectFaucetTokensButton = document.querySelector(COLLECT_TOKENS_BUTTON_SELECTOR);
+  if (!collectFaucetTokensButton) {
+    return;
+  }
+
+  collectFaucetTokensButton.addEventListener("click", async () => {
+    document.querySelector(CONTAINER_SELECTOR).classList.add("spinner-container");
+    const client = initVocdoniClient();
+    await client.collectFaucetTokens();
+    // document.reload();
+    showAvailableCredits();
+    document.querySelector(COLLECT_TOKENS_BUTTON_SELECTOR).classList.add("hide");
+    document.querySelector(NO_TOKENS_MESSAGE_SELECTOR).classList.add("hide");
+    document.querySelector(CONTAINER_SELECTOR).classList.remove("spinner-container");
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  showAvailableCredits();
+  collectFaucetTokensListener();
+});

--- a/app/packs/src/decidim/vocdoni/admin/available_credits.js
+++ b/app/packs/src/decidim/vocdoni/admin/available_credits.js
@@ -4,6 +4,8 @@ const CREDIT_SPAN_SELECTOR = ".js-vocdoni-credits-balance";
 const NO_TOKENS_MESSAGE_SELECTOR = ".js-vocdoni-credits-collect-faucet-tokens-section";
 const COLLECT_TOKENS_BUTTON_SELECTOR = ".js-vocdoni-credits-collect-faucet-tokens";
 const CONTAINER_SELECTOR = ".process-content";
+const ACTIONS_BUTTONS_SELECTOR = ".js-vocdoni-interruptible, #new_setup_ button[type=submit]";
+const SPINNER_CLASS = "spinner-container";
 
 const showAvailableCredits = async () => {
   const creditsSpan = document.querySelector(CREDIT_SPAN_SELECTOR);
@@ -16,7 +18,7 @@ const showAvailableCredits = async () => {
 
   if (clientInfo.balance === 0) {
     document.querySelector(NO_TOKENS_MESSAGE_SELECTOR).classList.remove("hide");
-    document.querySelectorAll(".js-vocdoni-interruptible").forEach((element) => {
+    document.querySelectorAll(ACTIONS_BUTTONS_SELECTOR).forEach((element) => {
       element.disabled = true;
     });
   }
@@ -31,14 +33,16 @@ const collectFaucetTokensListener = async () => {
   }
 
   collectFaucetTokensButton.addEventListener("click", async () => {
-    document.querySelector(CONTAINER_SELECTOR).classList.add("spinner-container");
+    document.querySelector(CONTAINER_SELECTOR).classList.add(SPINNER_CLASS);
     const client = initVocdoniClient();
     await client.collectFaucetTokens();
-    // document.reload();
     showAvailableCredits();
     document.querySelector(COLLECT_TOKENS_BUTTON_SELECTOR).classList.add("hide");
     document.querySelector(NO_TOKENS_MESSAGE_SELECTOR).classList.add("hide");
-    document.querySelector(CONTAINER_SELECTOR).classList.remove("spinner-container");
+    document.querySelector(CONTAINER_SELECTOR).classList.remove(SPINNER_CLASS);
+    document.querySelectorAll(ACTIONS_BUTTONS_SELECTOR).forEach((element) => {
+      element.disabled = false;
+    });
   });
 }
 

--- a/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
@@ -8,8 +8,7 @@ const setupElectionStep = async () => {
   }
 
   const createAnswersValuesOnElection = async () => {
-    const urlPrefix = window.location.pathname.split("/").filter((param) => param !== "steps").join("/");
-    const url = `${urlPrefix}/answers_values`;
+    const url = document.querySelector(".js-vocdoni-client").dataset.answersValuesElectionPath;
 
     return new Promise((resolve) => {
       fetch(url, {

--- a/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
@@ -7,6 +7,27 @@ const setupElectionStep = async () => {
     return;
   }
 
+  const createAnswersValuesOnElection = async () => {
+    const url = window.location.pathname.split('/').filter((param) => param != "steps") .join("/") + "/answers_values";
+
+    return new Promise((resolve) => {
+      fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": $("meta[name=csrf-token]").attr("content")
+        } })
+        .then((response) => response.json())
+        .then((data) => {
+          console.log("Successfully created the Answers values:", data);
+          resolve(data);
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+        });
+    });
+  }
+
   const onSuccess = (vocdoniElectionId) => {
     createElectionForm.querySelector("#setup_vocdoni_election_id").value = vocdoniElectionId;
     createElectionForm.submit();
@@ -25,11 +46,16 @@ const setupElectionStep = async () => {
   // If we do it with Vanilla JavaScript, the event is still submitted. This is a problem with Rails UJS, and we
   // need to use JQuery as a workaround
   // createElectionForm.addEventListener("submit", (event) => {
-  $("form.create_election").on("submit", (event) => {
+  $("form.create_election").on("submit", async (event) => {
     event.preventDefault();
 
     const setupElectionButton = createElectionForm.querySelector(".form-general-submit button");
     showLoadingSpinner(setupElectionButton);
+
+    const answersResponse = await createAnswersValuesOnElection();
+    if (answersResponse.status !== "ok") {
+      return {};
+    }
 
     const election = new CreateVocdoniElection({
       graphqlApiUrl: `${window.location.origin}/api`,

--- a/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
@@ -36,25 +36,13 @@ const setupElectionStep = async () => {
       graphqlApiUrl: `${window.location.origin}/api`,
       defaultLocale: document.querySelector(".js-vocdoni-client").dataset.defaultLocale,
       componentId: window.location.pathname.split("/")[5],
-      electionId: window.location.pathname.split("/")[8]
+      electionId: window.location.pathname.split("/")[8],
+      containerClass: ".process-content"
     }, onSuccess, onFailure);
     election.run();
   });
 }
 
-const showAvailableCredits = async () => {
-  const creditsSpan = document.querySelector(".js-vocdoni-balance-credits");
-  if (!creditsSpan) {
-    return;
-  }
-
-  const client = initVocdoniClient();
-  const clientInfo = await client.createAccount();
-
-  creditsSpan.innerHTML = clientInfo.balance;
-};
-
 document.addEventListener("DOMContentLoaded", () => {
   setupElectionStep();
-  showAvailableCredits();
 });

--- a/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
@@ -1,5 +1,4 @@
-import CreateVocdoniElection from "../utils/create_vocdoni_election";
-import { initVocdoniClient } from "../utils/init_vocdoni_client";
+import CreateVocdoniElection from "src/decidim/vocdoni/admin/utils/create_vocdoni_election";
 
 const setupElectionStep = async () => {
   // Setup election step

--- a/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/setup_election.js
@@ -8,7 +8,8 @@ const setupElectionStep = async () => {
   }
 
   const createAnswersValuesOnElection = async () => {
-    const url = window.location.pathname.split('/').filter((param) => param != "steps") .join("/") + "/answers_values";
+    const urlPrefix = window.location.pathname.split("/").filter((param) => param !== "steps").join("/");
+    const url = `${urlPrefix}/answers_values`;
 
     return new Promise((resolve) => {
       fetch(url, {
@@ -16,13 +17,13 @@ const setupElectionStep = async () => {
         headers: {
           "Content-Type": "application/json",
           "X-CSRF-Token": $("meta[name=csrf-token]").attr("content")
-        } })
-        .then((response) => response.json())
-        .then((data) => {
+        } }).
+        then((response) => response.json()).
+        then((data) => {
           console.log("Successfully created the Answers values:", data);
           resolve(data);
-        })
-        .catch((error) => {
+        }).
+        catch((error) => {
           console.error("Error:", error);
         });
     });
@@ -54,7 +55,7 @@ const setupElectionStep = async () => {
 
     const answersResponse = await createAnswersValuesOnElection();
     if (answersResponse.status !== "ok") {
-      return {};
+      return;
     }
 
     const election = new CreateVocdoniElection({

--- a/app/packs/src/decidim/vocdoni/admin/steps/vote.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/vote.js
@@ -134,11 +134,15 @@ const handleInterruptibleElectionActions = async () => {
 
 document.addEventListener("DOMContentLoaded", async () => {
   const client = initVocdoniClient();
-  const electionMetadata = await client.fetchElection();
-  console.log("ELECTION METADATA => ", electionMetadata);
-  console.log("ELECTION STATUS => ", ElectionStatus[electionMetadata.status]);
 
-  fetchTheVotesStats(electionMetadata);
-  handleElectionStatus(electionMetadata);
+  if (client.electionId) {
+    const electionMetadata = await client.fetchElection();
+    console.log("ELECTION METADATA => ", electionMetadata);
+    console.log("ELECTION STATUS => ", ElectionStatus[electionMetadata.status]);
+
+    fetchTheVotesStats(electionMetadata);
+    handleElectionStatus(electionMetadata);
+  }
+
   handleInterruptibleElectionActions();
 });

--- a/app/packs/src/decidim/vocdoni/admin/steps/vote.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/vote.js
@@ -1,10 +1,19 @@
-import { initVocdoniClient } from "../utils/init_vocdoni_client";
+import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
+import { ElectionStatus } from "@vocdoni/sdk";
 
-// Votes step
-//
+const ELECTION_VOTES_SELECTOR = ".js-votes-count";
+const INTERUPTIBLE_CONTINUE_BUTTON_SELECTOR = ".js-vocdoni-interruptible[data-action='continue']";
+const INTERUPTIBLE_PAUSE_BUTTON_SELECTOR = ".js-vocdoni-interruptible[data-action='pause']";
+const INTERUPTIBLE_CANCEL_BUTTON_SELECTOR = ".js-vocdoni-interruptible[data-action='cancel']";
+const INTERUPTIBLE_END_BUTTON_SELECTOR = ".js-vocdoni-interruptible[data-action='end']";
+const CONTAINER_SELECTOR = ".process-content";
+const INTERRUPTIBLE_FORM_SELECTOR = "#new_election_status_";
+const STATUS_FIELD_SELECTOR = "#election_status_status";
+
+
 // Fetch the votes from the API and show them in the UI
-const voteStep = async () => {
-  const electionVotesMetadataTable = document.querySelector(".js-votes-count");
+const fetchTheVotesStats = async (electionMetadata) => {
+  const electionVotesMetadataTable = document.querySelector(ELECTION_VOTES_SELECTOR);
   if (!electionVotesMetadataTable) {
     return;
   }
@@ -15,12 +24,10 @@ const voteStep = async () => {
   /*
    * Fetch the votes stats from the Vocdoni API
    *
-   * @param {object} client - The Vocdoni SDK client instantiated with the election ID and the wallet
+   * @param {object} electionMetadata - The election metadata with the results key
    * @returns void
    */
-  const fetchVotesStats = async (client) => {
-    const electionMetadata = await client.fetchElection();
-    console.log("ELECTION METADATA => ", electionMetadata);
+  const fetchVotesStats = async () => {
     const results = electionMetadata.results;
 
     for (let idx = 0; idx < results.length; idx += 1) {
@@ -34,11 +41,104 @@ const voteStep = async () => {
     }
   }
 
-  const client = initVocdoniClient();
-  fetchVotesStats(client);
-  setInterval(fetchVotesStats, WAIT_TIME_MS, client);
+  fetchVotesStats();
+  setInterval(fetchVotesStats, WAIT_TIME_MS);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  voteStep();
+
+/* Handle the election status
+ * Shows the different buttons depending on the election status
+ *
+ * @param {object} electionMetadata - The election metadata
+ *
+ * @returns void
+ */
+const handleElectionStatus = (electionMetadata) => {
+  const continueButton = document.querySelector(INTERUPTIBLE_CONTINUE_BUTTON_SELECTOR);
+  const pauseButton = document.querySelector(INTERUPTIBLE_PAUSE_BUTTON_SELECTOR);
+  const cancelButton = document.querySelector(INTERUPTIBLE_CANCEL_BUTTON_SELECTOR);
+  const endButton = document.querySelector(INTERUPTIBLE_END_BUTTON_SELECTOR);
+
+  if (!cancelButton || !endButton) {
+    return;
+  }
+
+  switch (electionMetadata.status) {
+  case ElectionStatus.PAUSED:
+    continueButton.classList.remove("hide");
+    cancelButton.classList.remove("hide");
+    endButton.classList.remove("hide");
+    break;
+  case ElectionStatus.READY:
+    pauseButton.classList.remove("hide");
+    cancelButton.classList.remove("hide");
+    endButton.classList.remove("hide");
+    break;
+  default:
+    console.log("Unknown election status");
+  }
+}
+
+// When interruptible is enabled, handle the different actions that the admin can do
+const handleInterruptibleElectionActions = async () => {
+  const interruptibleForm = document.querySelector(INTERRUPTIBLE_FORM_SELECTOR);
+  if (!interruptibleForm) {
+    return;
+  }
+
+  // If we do it with Vanilla JavaScript, the event is still submitted. This is a problem with Rails UJS, and we
+  // need to use JQuery as a workaround
+  // interruptibleForm.addEventListener("submit", (event) => {
+  $(INTERRUPTIBLE_FORM_SELECTOR).on("submit", async (event) => {
+    event.preventDefault();
+
+    document.querySelector(CONTAINER_SELECTOR).classList.add("spinner-container");
+    const action = document.activeElement.dataset.action;
+    console.log("ACTION => ", action);
+    const client = initVocdoniClient();
+    const oldElectionMetadata = await client.fetchElection();
+    const oldElectionStatus = oldElectionMetadata.status;
+    const statusField = document.querySelector(STATUS_FIELD_SELECTOR);
+    console.log(client);
+
+    switch (action) {
+    case "continue":
+      await client.continueElection();
+      statusField.value = "vote";
+      break;
+    case "pause":
+      await client.pauseElection();
+      statusField.value = "paused";
+      break;
+    case "cancel":
+      await client.cancelElection();
+      statusField.value = "canceled";
+      break;
+    case "end":
+      await client.endElection();
+      statusField.value = "vote_ended";
+      break;
+    default:
+      console.log("Unknown action");
+    }
+
+    document.querySelector(CONTAINER_SELECTOR).classList.remove("spinner-container");
+    const newElectionMetadata = await client.fetchElection();
+    const newElectionStatus = newElectionMetadata.status;
+    if (oldElectionStatus !== newElectionStatus) {
+      console.log(`Election status changed from ${oldElectionStatus} to ${newElectionStatus}`);
+      event.currentTarget.submit();
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const client = initVocdoniClient();
+  const electionMetadata = await client.fetchElection();
+  console.log("ELECTION METADATA => ", electionMetadata);
+  console.log("ELECTION STATUS => ", ElectionStatus[electionMetadata.status]);
+
+  fetchTheVotesStats(electionMetadata);
+  handleElectionStatus(electionMetadata);
+  handleInterruptibleElectionActions();
 });

--- a/app/packs/src/decidim/vocdoni/admin/steps/vote.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/vote.js
@@ -30,6 +30,7 @@ const fetchTheVotesStats = async (electionMetadata) => {
   const fetchVotesStats = async () => {
     const results = electionMetadata.results;
 
+    console.group("Partial Results");
     for (let idx = 0; idx < results.length; idx += 1) {
       const $questionAnswersCells = $(`td[data-question-idx="${idx}"]`);
       for (const answerCell of $questionAnswersCells) {
@@ -39,6 +40,7 @@ const fetchTheVotesStats = async (electionMetadata) => {
         console.log(`FOR QUESTION ${idx} - ANSWER ${answerValue} - VOTES ${answerVotes}`);
       }
     }
+    console.groupEnd();
   }
 
   fetchVotesStats();

--- a/app/packs/src/decidim/vocdoni/admin/steps/vote_ended.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/vote_ended.js
@@ -1,44 +1,55 @@
 import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
 
-// Votes step
+const ELECTION_RESULTS_FORM_SELECTOR = "form#new_results_";
+const ERROR_MESSAGE_SELECTOR = ".js-votes-results-error";
+const FORM_NEW_RESULTS_BUTTON_SELECTOR = "form#new_results_ button";
+
+// Vote Ended step
 //
 // Fetch the votes from the API and saves them to the form
-const voteEndedStep = async () => {
-  const electionResultsForm = document.querySelector(".js-votes-results");
+const voteEndedStep = () => {
+  const electionResultsForm = document.querySelector(ELECTION_RESULTS_FORM_SELECTOR);
   if (!electionResultsForm) {
     return;
   }
 
   /*
-   * Fetch the votes stats from the Vocdoni API
+   * Fetch the votes results from the Vocdoni API
    *
    * @param {object} client - The Vocdoni SDK client instantiated with the election ID and the wallet
    * @returns void
    */
-  const fetchVotesStats = async (client) => {
+  const fetchVotesResults = async (client) => {
     const electionMetadata = await client.fetchElection();
     console.log("ELECTION METADATA => ", electionMetadata);
     const results = electionMetadata.results;
 
     if (!results) {
       console.log("No results yet. Wait a couple of minutes.");
-      document.querySelector(".js-votes-results-error-fetch").classList.remove("hide");
+      document.querySelector(ERROR_MESSAGE_SELECTOR).classList.remove("hide");
       return;
     }
 
+    console.group("Final Results");
     for (let idx = 0; idx < results.length; idx += 1) {
       const questionAnswersInputs = document.querySelectorAll(`*[data-question-idx="${idx}"]`);
       for (const answerInput of questionAnswersInputs) {
-        const answerId = answerInput.dataset.answerId;
-        const answerVotes = results[idx][answerId];
-        answerInput.value = answerVotes;
-        console.log(`FINAL FOR QUESTION ${idx} - ANSWER ${answerId} - VOTES ${answerVotes}`);
+        const answerValue = answerInput.dataset.answerValue;
+        const answerVotes = results[idx][answerValue];
+
+        if (typeof answerVotes !== "undefined") {
+          answerInput.value = answerVotes;
+          console.log(`FINAL RESULT FOR QUESTION ${idx} - ANSWER ${answerValue} - VOTES ${answerVotes}`);
+        }
       }
     }
+    console.groupEnd();
+
+    document.querySelector(FORM_NEW_RESULTS_BUTTON_SELECTOR).disabled = false;
   }
 
   const client = initVocdoniClient();
-  fetchVotesStats(client);
+  fetchVotesResults(client);
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/app/packs/src/decidim/vocdoni/admin/steps/vote_ended.js
+++ b/app/packs/src/decidim/vocdoni/admin/steps/vote_ended.js
@@ -1,4 +1,4 @@
-import { initVocdoniClient } from "../utils/init_vocdoni_client";
+import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
 
 // Votes step
 //

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -56,14 +56,6 @@ export default class CreateVocdoniElection {
   async _setVocdoniClient() {
     this.client = initVocdoniClient();
 
-    const clientInfo = await this.client.createAccount();
-    if (clientInfo.balance === 0) {
-      document.querySelector(".js-vocdoni-credits-collect-faucet-tokens").classList.remove("hide");
-      document.querySelector(".js-vocdoni-credits-balance-message").classList.remove("hide");
-    } else {
-      document.querySelector(".js-vocdoni-credits-balance-message").classList.add("hide");
-    }
-
     console.log("CLIENT => ", this.client);
   }
 

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -1,5 +1,5 @@
 import { Election, PlainCensus } from "@vocdoni/sdk";
-import { initVocdoniClient } from "./init_vocdoni_client";
+import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
 
 /*
  * Creates an Election in the Vocdoni API

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -11,6 +11,7 @@ import { initVocdoniClient } from "./init_vocdoni_client";
  * @property {string} options.defaultLocale The default locale of the Election
  * @property {number|string} options.componentId The ID of the Vocdoni Component in Decidim
  * @property {number|string} options.electionId The ID of the Vocdoni Election in Decidim
+ * @property {string} options.containerClass The class of the container where the election will be rendered. Used to show a spinner.
  * @param {function} onSuccess A callback function to be run when the Election is successfully sent to the API
  * @param {function} onFailure A callback function to be run when the Election sent to the API has a failure
  *
@@ -23,6 +24,7 @@ export default class CreateVocdoniElection {
     this.defaultLocale = options.defaultLocale;
     this.componentId = options.componentId;
     this.electionId = options.electionId;
+    this.containerClass = options.containerClass;
     this.onSuccess = onSuccess;
     this.onFailure = onFailure;
     this.client = null;
@@ -56,7 +58,10 @@ export default class CreateVocdoniElection {
 
     const clientInfo = await this.client.createAccount();
     if (clientInfo.balance === 0) {
-      await this.client.collectFaucetTokens();
+      document.querySelector(".js-vocdoni-credits-collect-faucet-tokens").classList.remove("hide");
+      document.querySelector(".js-vocdoni-credits-balance-message").classList.remove("hide");
+    } else {
+      document.querySelector(".js-vocdoni-credits-balance-message").classList.add("hide");
     }
 
     console.log("CLIENT => ", this.client);
@@ -68,17 +73,22 @@ export default class CreateVocdoniElection {
    * @returns {void}
    */
   async _createElection() {
+
     let result = null;
 
     try {
       const election = await this._initializeElection(this.defaultLocale);
       console.log("ELECTION => ", election);
 
+      document.querySelector(this.containerClass).classList.add("spinner-container");
+
       const vocdoniElectionId = await this.client.createElection(election);
       result = `OK! VOCDONI ELECTION ID => ${vocdoniElectionId}`;
+      document.querySelector(this.containerClass).classList.remove("spinner-container");
       this.onSuccess(vocdoniElectionId);
     } catch (error) {
       result = `ERROR! ${error}`;
+      document.querySelector(this.containerClass).classList.remove("spinner-container");
       this.onFailure();
     }
 

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -11,7 +11,8 @@ import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_
  * @property {string} options.defaultLocale The default locale of the Election
  * @property {number|string} options.componentId The ID of the Vocdoni Component in Decidim
  * @property {number|string} options.electionId The ID of the Vocdoni Election in Decidim
- * @property {string} options.containerClass The class of the container where the election will be rendered. Used to show a spinner.
+ * @property {string} options.containerClass The class of the container where the election will be rendered.
+ *                               Used to show a spinner and to save the electionMetadata for showing in the markup if there's any error.
  * @param {function} onSuccess A callback function to be run when the Election is successfully sent to the API
  * @param {function} onFailure A callback function to be run when the Election sent to the API has a failure
  *
@@ -121,6 +122,10 @@ export default class CreateVocdoniElection {
 
     let electionMetadata = await this._getElectionMetadata();
     electionMetadata = electionMetadata.data.component.election;
+
+    // Save the electionMetadata in the DOM to show it in the markup if there's any error
+    const errorDetails = document.querySelector(this.containerClass).querySelector(".js-election-create-error-message-details");
+    errorDetails.innerHTML = JSON.stringify(electionMetadata, null, 4);
 
     const walletsAddresses = electionMetadata.voters.map((voter) => voter.wallet_address);
     const census = this._initializeCensus(walletsAddresses);

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -131,6 +131,7 @@ export default class CreateVocdoniElection {
       endDate: Date.parse(electionMetadata.endTime),
       census,
       electionType: {
+        interruptible: electionMetadata.interruptible,
         secretUntilTheEnd: electionMetadata.secretUntilTheEnd
       }
     });
@@ -181,6 +182,7 @@ export default class CreateVocdoniElection {
                 streamUri
                 startTime
                 endTime
+                interruptible
                 secretUntilTheEnd
                 voters {
                   wallet_address

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -67,8 +67,6 @@ export default class CreateVocdoniElection {
    */
   async _createElection() {
 
-    let result = null;
-
     try {
       const election = await this._initializeElection(this.defaultLocale);
       console.log("ELECTION => ", election);
@@ -76,16 +74,14 @@ export default class CreateVocdoniElection {
       document.querySelector(this.containerClass).classList.add("spinner-container");
 
       const vocdoniElectionId = await this.client.createElection(election);
-      result = `OK! VOCDONI ELECTION ID => ${vocdoniElectionId}`;
-      document.querySelector(this.containerClass).classList.remove("spinner-container");
+      console.log("RESULT => OK! VOCDONI ELECTION ID ", vocdoniElectionId);
       this.onSuccess(vocdoniElectionId);
     } catch (error) {
-      result = `ERROR! ${error}`;
-      document.querySelector(this.containerClass).classList.remove("spinner-container");
+      console.error("RESULT => ERROR! ", error);
       this.onFailure();
+    } finally {
+      document.querySelector(this.containerClass).classList.remove("spinner-container");
     }
-
-    console.log("RESULT => ", result);
   }
 
   /*

--- a/app/packs/src/decidim/vocdoni/voter/census-utils.js
+++ b/app/packs/src/decidim/vocdoni/voter/census-utils.js
@@ -1,0 +1,60 @@
+import { VocdoniSDKClient } from "@vocdoni/sdk";
+
+/*
+ * Instantiate the Wallet object given a login form with the email and the date of birth
+ * of the potenital voter
+ *
+ * @param {object} $loginForm The jQuery Element with the form for logging in
+ *
+ * @returns {object} the Wallet object generated or an empty object
+ */
+export const walletFromLoginForm = ($loginForm) => {
+  if ($loginForm === null) {
+    return {};
+  }
+
+  const email = $loginForm.find("#login_email").val();
+  let bornAtDay = $loginForm.find("#login_day").val();
+  let bornAtMonth = $loginForm.find("#login_month").val();
+  const bornAtYear = $loginForm.find("#login_year").val();
+
+  if (!email.includes("@")) {
+    return {};
+  }
+
+  if (bornAtYear.length !== 4) {
+    return {};
+  }
+
+  if (bornAtDay.length === 1) {
+    bornAtDay = `0${bornAtDay}`;
+  }
+
+  if (bornAtMonth.length === 1) {
+    bornAtMonth = `0${bornAtMonth}`;
+  }
+
+  const bornAt = `${bornAtYear}-${bornAtMonth}-${bornAtDay}`;
+
+  console.group("Wallet data");
+  console.log("EMAIL => ", email);
+  console.log("BORN AT => ", bornAt);
+  console.groupEnd();
+
+  for (const value of [email, bornAtDay, bornAtMonth, bornAtYear]) {
+    if (value === "") {
+      return {};
+    }
+  }
+
+  const userWallet = VocdoniSDKClient.generateWalletFromData([email, bornAt]);
+
+  return userWallet;
+}
+
+export const checkIfWalletIsInCensus = async (env, wallet, electionId) => {
+  const client = new VocdoniSDKClient({ env, wallet })
+  client.setElectionId(electionId);
+  const isInCensus = await client.isInCensus();
+  return isInCensus;
+}

--- a/app/packs/src/decidim/vocdoni/voter/census-utils.js
+++ b/app/packs/src/decidim/vocdoni/voter/census-utils.js
@@ -13,7 +13,7 @@ export const walletFromLoginForm = ($loginForm) => {
     return {};
   }
 
-  const email = $loginForm.find("#login_email").val();
+  const email = $loginForm.find("#login_email").val().toLowerCase();
   let bornAtDay = $loginForm.find("#login_day").val();
   let bornAtMonth = $loginForm.find("#login_month").val();
   const bornAtYear = $loginForm.find("#login_year").val();

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
-import { VocdoniSDKClient } from "@vocdoni/sdk";
+import { ElectionStatus, VocdoniSDKClient } from "@vocdoni/sdk";
 
 import VoteQuestionsComponent from "./vote_questions.component";
 import VoteComponent from "./setup-vote";
 import PreviewVoteComponent from "./setup-preview";
+import { walletFromLoginForm, checkIfWalletIsInCensus } from "./census-utils";
 
 /*
  * Mount the VoteComponent object and bind the events to the UI
@@ -72,97 +73,29 @@ const mountVoteComponent = async (voteComponent, $voteWrapper, questionsComponen
   });
 }
 
-/*
- * Generate the VoteComponent object in case the Wallet is in the census
- * or show an error message if it is not.
- *
- * @param {string} vocdoniEnv The environment of the Vocdoni API
- * @param {object} userWallet The Wallet object generated from the login form
- * @param {string} electionUniqueId The unique ID of the election in the Vocdoni API
- *
- * @return {array} An array with two elements:
- *  - The VoteComponent object or null if the wallet is not in the census
- *  - A boolean with true if we should show the next step or false if not
- */
-const voteComponentGenerator = async (vocdoniEnv, userWallet, electionUniqueId) => {
-  const checkIfWalletIsInCensus = async (wallet, electionId) => {
-    const client = new VocdoniSDKClient({
-      env: vocdoniEnv,
-      wallet: wallet
-    })
-    client.setElectionId(electionId);
-    const isInCensus = await client.isInCensus();
-    return isInCensus;
-  }
-
-  let voteComponent = null;
-  let nextStep = false;
-
-  if (userWallet === {}) {
-    return [voteComponent, nextStep];
-  }
-
-  const isInCensus = await checkIfWalletIsInCensus(userWallet, electionUniqueId);
-  console.log("IS IN CENSUS => ", isInCensus);
-  if (isInCensus) {
-    console.log("OK!! Wallet is in census");
-    voteComponent = new VoteComponent({vocdoniEnv: vocdoniEnv, electionUniqueId: electionUniqueId, wallet: userWallet});
-    nextStep = true;
-  }
-
-  return [voteComponent, nextStep];
-}
 
 /*
- * Instantiate the Wallet object given a login form with the email and the date of birth
- * of the potenital voter
+ * Check if the election is open
  *
- * @param {object} $loginForm The jQuery Element with the form for logging in
+ * @param {string} env - The environment of the Vocdoni API
+ * @param {object} wallet - The Wallet object generated from the login form
+ * @param {string} electionUniqueId - The unique ID of the election in the Vocdoni API
  *
- * @returns {object} the Wallet object generated or an empty object
+ * @return {boolean} A boolean with true if the election is open or false if not
+ *   (if the election is not open, the next step is not shown)
+ *   (if the election is open, the next step is shown)
  */
-const walletFromLoginForm = ($loginForm) => {
-  if ($loginForm === null) {
-    return {};
-  }
+const checkIfElectionIsOpen = async (env, wallet, electionUniqueId) => {
+  const client = new VocdoniSDKClient({ env, wallet })
+  client.setElectionId(electionUniqueId);
+  const election = await client.fetchElection();
+  const electionStatus = ElectionStatus[election.status];
+  const isElectionOpen = electionStatus === ElectionStatus.OPEN;
 
-  const email = $loginForm.find("#login_email").val();
-  let bornAtDay = $loginForm.find("#login_day").val();
-  let bornAtMonth = $loginForm.find("#login_month").val();
-  const bornAtYear = $loginForm.find("#login_year").val();
+  console.log("ELECTION => ", election);
+  console.log("STATUS => ", electionStatus);
 
-  if (!email.includes("@")) {
-    return {};
-  }
-
-  if (bornAtYear.length !== 4) {
-    return {};
-  }
-
-  if (bornAtDay.length === 1) {
-    bornAtDay = `0${bornAtDay}`;
-  }
-
-  if (bornAtMonth.length === 1) {
-    bornAtMonth = `0${bornAtMonth}`;
-  }
-
-  const bornAt = `${bornAtYear}-${bornAtMonth}-${bornAtDay}`;
-
-  console.group("Wallet data");
-  console.log("EMAIL => ", email);
-  console.log("BORN AT => ", bornAt);
-  console.groupEnd();
-
-  for (const value of [email, bornAtDay, bornAtMonth, bornAtYear]) {
-    if (value === "") {
-      return {};
-    }
-  }
-
-  const userWallet = VocdoniSDKClient.generateWalletFromData([email, bornAt]);
-
-  return userWallet;
+  return isElectionOpen;
 }
 
 $(() => {
@@ -187,34 +120,55 @@ $(() => {
   $loginForm.on("submit", async (event) => {
     event.preventDefault();
 
-    const showErrorMessage = () => {
+    const showLoginErrorMessage = () => {
       console.log("KO -> Wallet is not in census");
       $(".js-login_error").removeClass("hide");
     }
 
+    const showElectionClosedErrorMessage = () => {
+      console.log("Election is not open");
+      $(".vote-wrapper").find(".js-election_not_open").removeClass("hide");
+    }
+
     const electionUniqueId = $voteWrapper.data("electionUniqueId");
     let voteComponent = null;
-    let nextStep = null;
 
     if ($voteWrapper.data("preview") === true) {
       console.log("Preview mode");
       voteComponent = new PreviewVoteComponent({electionUniqueId});
-      nextStep = true;
     } else {
       const userWallet = walletFromLoginForm($loginForm);
       const vocdoniEnv = $voteWrapper.data("vocdoniEnv");
-      [voteComponent, nextStep] = await voteComponentGenerator(vocdoniEnv, userWallet, electionUniqueId);
+
+      if (userWallet === {}) {
+        showLoginErrorMessage();
+        return;
+      }
+
+      const isInCensus = await checkIfWalletIsInCensus(vocdoniEnv, userWallet, electionUniqueId);
+      console.log("IS IN CENSUS => ", isInCensus);
+
+      if (!isInCensus) {
+        showLoginErrorMessage();
+        return;
+      }
+
+      console.log("OK!! Wallet is in census");
+
+      const isElectionOpen = await checkIfElectionIsOpen(vocdoniEnv, userWallet, electionUniqueId);
+      console.log("IS ELECTION OPEN => ", isElectionOpen);
+
+      if (!isElectionOpen) {
+        showElectionClosedErrorMessage();
+        return;
+      }
+
+      voteComponent = new VoteComponent({vocdoniEnv, electionUniqueId, userWallet});
     }
 
-    if (!nextStep) {
-      showErrorMessage();
-    }
-
-    if (nextStep) {
-      $("#login").foundation("toggle");
-      $("#step-0").foundation("toggle");
-      mountVoteComponent(voteComponent, $voteWrapper, questionsComponent);
-    }
+    $("#login").foundation("toggle");
+    $("#step-0").foundation("toggle");
+    mountVoteComponent(voteComponent, $voteWrapper, questionsComponent);
   });
 });
 /* eslint-enable no-console */

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -137,14 +137,14 @@ $(() => {
       voteComponent = new PreviewVoteComponent({electionUniqueId});
     } else {
       const wallet = walletFromLoginForm($loginForm);
-      const vocdoniEnv = $voteWrapper.data("vocdoniEnv");
+      const env = $voteWrapper.data("vocdoniEnv");
 
       if (wallet === {}) {
         showLoginErrorMessage();
         return;
       }
 
-      const isInCensus = await checkIfWalletIsInCensus(vocdoniEnv, wallet, electionUniqueId);
+      const isInCensus = await checkIfWalletIsInCensus(env, wallet, electionUniqueId);
       console.log("IS IN CENSUS => ", isInCensus);
 
       if (!isInCensus) {
@@ -154,7 +154,7 @@ $(() => {
 
       console.log("OK!! Wallet is in census");
 
-      const isElectionOpen = await checkIfElectionIsOpen(vocdoniEnv, wallet, electionUniqueId);
+      const isElectionOpen = await checkIfElectionIsOpen(env, wallet, electionUniqueId);
       console.log("IS ELECTION OPEN => ", isElectionOpen);
 
       if (!isElectionOpen) {
@@ -162,7 +162,7 @@ $(() => {
         return;
       }
 
-      voteComponent = new VoteComponent({vocdoniEnv, electionUniqueId, wallet});
+      voteComponent = new VoteComponent({env, electionUniqueId, wallet});
     }
 
     $("#login").foundation("toggle");

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -136,15 +136,15 @@ $(() => {
       console.log("Preview mode");
       voteComponent = new PreviewVoteComponent({electionUniqueId});
     } else {
-      const userWallet = walletFromLoginForm($loginForm);
+      const wallet = walletFromLoginForm($loginForm);
       const vocdoniEnv = $voteWrapper.data("vocdoniEnv");
 
-      if (userWallet === {}) {
+      if (wallet === {}) {
         showLoginErrorMessage();
         return;
       }
 
-      const isInCensus = await checkIfWalletIsInCensus(vocdoniEnv, userWallet, electionUniqueId);
+      const isInCensus = await checkIfWalletIsInCensus(vocdoniEnv, wallet, electionUniqueId);
       console.log("IS IN CENSUS => ", isInCensus);
 
       if (!isInCensus) {
@@ -154,7 +154,7 @@ $(() => {
 
       console.log("OK!! Wallet is in census");
 
-      const isElectionOpen = await checkIfElectionIsOpen(vocdoniEnv, userWallet, electionUniqueId);
+      const isElectionOpen = await checkIfElectionIsOpen(vocdoniEnv, wallet, electionUniqueId);
       console.log("IS ELECTION OPEN => ", isElectionOpen);
 
       if (!isElectionOpen) {
@@ -162,7 +162,7 @@ $(() => {
         return;
       }
 
-      voteComponent = new VoteComponent({vocdoniEnv, electionUniqueId, userWallet});
+      voteComponent = new VoteComponent({vocdoniEnv, electionUniqueId, wallet});
     }
 
     $("#login").foundation("toggle");

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -89,11 +89,10 @@ const checkIfElectionIsOpen = async (env, wallet, electionUniqueId) => {
   const client = new VocdoniSDKClient({ env, wallet })
   client.setElectionId(electionUniqueId);
   const election = await client.fetchElection();
-  const electionStatus = ElectionStatus[election.status];
-  const isElectionOpen = electionStatus === ElectionStatus.OPEN;
+  const isElectionOpen = election.status === ElectionStatus.READY;
 
   console.log("ELECTION => ", election);
-  console.log("STATUS => ", electionStatus);
+  console.log("STATUS => ", ElectionStatus[election.status]);
 
   return isElectionOpen;
 }

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -40,13 +40,13 @@ const mountVoteComponent = async (voteComponent, $voteWrapper, questionsComponen
       validVoteFn(formData);
       questionsComponent.voteCasted = true;
     },
-    onFinish(voteId) {
+    onFinish(voteId, env) {
       console.log("Vote finished");
       console.log("VOTE ID => ", voteId);
       $voteWrapper.find("#submitting").addClass("hide");
       $voteWrapper.find("#vote_cast").removeClass("hide");
       $voteWrapper.find("#vote-receipt").val(voteId);
-      $voteWrapper.find(".verify_ballot").attr("href", `https://dev.explorer.vote/verify/#/${voteId}`);
+      $voteWrapper.find(".verify_ballot").attr("href", `https://${env}.explorer.vote/verify/#/${voteId}`);
     },
     onBindVerifyBallotButton(onEventTriggered) {
       $(".verify_ballot").on("click", onEventTriggered);

--- a/app/packs/src/decidim/vocdoni/voter/setup-preview.js
+++ b/app/packs/src/decidim/vocdoni/voter/setup-preview.js
@@ -26,7 +26,7 @@ export default class PreviewVoteComponent {
           console.log("VOTE => ", vote);
           this.fakeSubmission(vote).then((ballot) => {
             console.log("BALLOT => ", ballot);
-            onFinish(ballot.voteId);
+            onFinish(ballot.voteId, "preview");
           });
         },
         () => {

--- a/app/packs/src/decidim/vocdoni/voter/setup-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/setup-vote.js
@@ -90,7 +90,7 @@ export default class VoteComponent {
             console.log(ballot);
 
             if (ballot.status === "OK") {
-              onFinish(ballot.voteId);
+              onFinish(ballot.voteId, this.env);
             } else {
               onInvalid(ballot.message);
             }

--- a/app/packs/src/decidim/vocdoni/voter/setup-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/setup-vote.js
@@ -7,7 +7,7 @@ import { VocdoniSDKClient, Vote } from "@vocdoni/sdk";
  * Submit a vote to the Vocdoni API
  *
  * @param {object} options All the different options that interact with Submitting a vote
- * @property {string} options.vocdoniEnv - The environment of the Vocdoni API
+ * @property {string} options.env - The environment of the Vocdoni API
  * @property {string} options.electionId - The election ID to vote in
  * @property {object} options.wallet - The wallet to use to sign the vote
  * @property {array} options.voteValue - The values of the votes to submit
@@ -18,8 +18,9 @@ import { VocdoniSDKClient, Vote } from "@vocdoni/sdk";
  *   - If it was a failure, the format will be `{status: "ERROR", message: error}`
  */
 const submitVote = async (options) => {
+  console.log("OPT", options);
   const client = new VocdoniSDKClient({
-    env: options.vocdoniEnv,
+    env: options.env,
     wallet: options.wallet
   });
   console.log("CLIENT => ", client);
@@ -30,17 +31,15 @@ const submitVote = async (options) => {
   //
   // TODO: we should pinpoint what exactly is the culprit of this issue
   // and if it's a bug in the SDK, we should fix it there
-  if (typeof client.url === "undefined") {
-    switch (options.vocdoniEnv) {
-    case "prd":
-      client.url = "https://api.vocdoni.net/v2";
-      break;
-    case "stg":
-      client.url = "https://api-stg.vocdoni.net/v2";
-      break;
-    default:
-      client.url = "https://api-dev.vocdoni.net/v2";
-    }
+  switch (options.env) {
+  case "prd":
+    client.url = "https://api.vocdoni.net/v2";
+    break;
+  case "stg":
+    client.url = "https://api-stg.vocdoni.net/v2";
+    break;
+  default:
+    client.url = "https://api-dev.vocdoni.net/v2";
   }
 
   const votesLeft = await client.votesLeftCount();
@@ -66,8 +65,8 @@ const submitVote = async (options) => {
 
 // A vote component, to send the real votes to the Vocdoni API, using the Vocdoni SDK
 export default class VoteComponent {
-  constructor({ vocdoniEnv, electionUniqueId, wallet }) {
-    this.vocdoniEnv = vocdoniEnv;
+  constructor({ env, electionUniqueId, wallet }) {
+    this.env = env;
     this.electionUniqueId = electionUniqueId;
     this.wallet = wallet;
   }
@@ -105,12 +104,12 @@ export default class VoteComponent {
   }
   async submit(vote) {
     console.log("Submiting vote to Vocdoni API with:");
-    console.log("- ENV => ", this.vocdoniEnv);
+    console.log("- ENV => ", this.env);
     console.log("- ELECTION ID => ", this.electionUniqueId);
     console.log("- WALLET => ", this.wallet);
     console.log("- VALUE => ", vote);
     const response = await submitVote({
-      env: this.vocdoniEnv,
+      env: this.env,
       electionId: this.electionUniqueId,
       wallet: this.wallet,
       voteValue: vote

--- a/app/packs/stylesheets/decidim/vocdoni/admin/vocdoni.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/admin/vocdoni.scss
@@ -1,3 +1,5 @@
+$white: #fff;
+
 // When we migrate to TailwindCSS, this will be removed :D
 .vocdoni-logo-wrapper {
   margin-top: 2rem;
@@ -11,4 +13,38 @@
 // We should fix this upstream
 .button.primary {
   color: white;
+}
+
+.spinner-container {
+  position: relative;
+  cursor: wait;
+
+  &::before{
+    content: " ";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba($white, .8);
+    z-index: 1;
+  }
+
+  &::after{
+    -webkit-animation: animation-spin 800ms infinite linear;
+    animation: animation-spin 800ms infinite linear;
+    width: 25px;
+    height: 25px;
+    box-sizing: border-box;
+    border-radius: 50%;
+    border: 3px solid #e8e8e8;
+    border-right-color: var(--primary);
+    display: inline-block;
+    position: absolute;
+    content: "";
+    vertical-align: middle;
+    z-index: 1;
+    top: 47%;
+    left: 47%;
+  }
 }

--- a/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
@@ -220,7 +220,7 @@
     font-size: 80%;
     text-transform: uppercase;
     letter-spacing: .01em;
-    color: $primary;
+    color: var(--primary);
   }
 
   &__edit-answer{
@@ -242,7 +242,7 @@
     height: 10px;
     margin: 10px auto;
     border-radius: 50px;
-    background: $primary;
+    background: var(--primary);
 
     &:nth-child(odd){
       animation: dotTop 1s infinite ease-in-out;

--- a/app/packs/stylesheets/decidim/vocdoni/focus/_focus.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/focus/_focus.scss
@@ -126,3 +126,9 @@
     }
   }
 }
+
+// Fix for external link indicator
+a img + .external-link-indicator {
+  top: -10px;
+  right: -15px;
+}

--- a/app/packs/stylesheets/decidim/vocdoni/vocdoni.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/vocdoni.scss
@@ -6,3 +6,12 @@
 .card__block ul li:not(:first-child) strong{
   font-size: 100%;
 }
+
+// There's a bug on Decidim related with the Copy button on Share modal
+// I proposed a fix and when that's accepted, backported and released
+// We can remove this rule
+//
+// @see https://github.com/decidim/decidim/pull/10526
+.button.primary, .button.primary:hover {
+  background-color: var(--primary);
+}

--- a/app/permissions/decidim/vocdoni/permissions.rb
+++ b/app/permissions/decidim/vocdoni/permissions.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def can_vote?
-        election.published? && election.ongoing? && !election.canceled? && !election.paused?
+        election.published? && election.ongoing? && !election.finished?
       end
 
       def election

--- a/app/permissions/decidim/vocdoni/permissions.rb
+++ b/app/permissions/decidim/vocdoni/permissions.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def can_vote?
-        election.published? && election.ongoing?
+        election.published? && election.ongoing? && !election.canceled? && !election.paused?
       end
 
       def election

--- a/app/views/decidim/vocdoni/admin/answers/edit.html.erb
+++ b/app/views/decidim/vocdoni/admin/answers/edit.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(answer.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for([election, question, @form], html: { class: "form edit_answer" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/answers/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/answers/index.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title">

--- a/app/views/decidim/vocdoni/admin/answers/new.html.erb
+++ b/app/views/decidim/vocdoni/admin/answers/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for([election, question, @form], html: { class: "form new_answer" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/census/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/census/index.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(election.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <% if @status.pending_upload? %> <div class="card">
     <div class="card-divider">
       <h2 class="card-title">

--- a/app/views/decidim/vocdoni/admin/elections/_form.html.erb
+++ b/app/views/decidim/vocdoni/admin/elections/_form.html.erb
@@ -35,5 +35,9 @@
     <div class="row column">
       <%= form.check_box :secret_until_the_end, { checked: election&.election_type&.fetch("secret_until_the_end", false) } %>
     </div>
+
+    <div class="row column">
+      <%= form.check_box :interruptible, { checked: election&.election_type&.fetch("interruptible", true) } %>
+    </div>
   </div>
 </div>

--- a/app/views/decidim/vocdoni/admin/elections/edit.html.erb
+++ b/app/views/decidim/vocdoni/admin/elections/edit.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(election.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for(@form, html: { class: "form edit_election" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/elections/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/elections/index.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title">

--- a/app/views/decidim/vocdoni/admin/elections/new.html.erb
+++ b/app/views/decidim/vocdoni/admin/elections/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for(@form, html: { class: "form new_election" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/questions/edit.html.erb
+++ b/app/views/decidim/vocdoni/admin/questions/edit.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(question.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for([election, @form], html: { class: "form edit_question" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/questions/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/questions/index.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(election.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <div class="card">
   <div class="card-divider">
     <h2 class="card-title">

--- a/app/views/decidim/vocdoni/admin/questions/new.html.erb
+++ b/app/views/decidim/vocdoni/admin/questions/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for([election, @form], html: { class: "form new_question" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/admin/steps/_available_credits.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_available_credits.html.erb
@@ -1,0 +1,21 @@
+<div class="card-divider">
+  <p class="label secondary">
+  <%= icon "credit-card", role: "img", "aria-hidden": true %>&nbsp;
+  <%= t("available", scope: "decidim.vocdoni.admin.steps.credits") %>:&nbsp;
+  <span class="js-vocdoni-credits-balance">
+    <span class="loading-spinner"></span>
+  </span>
+  </p>
+</div>
+
+<div class="hide card-section js-vocdoni-credits-collect-faucet-tokens-section">
+  <div class="callout alert">
+    <p>
+    <%= t("warning", scope: "decidim.vocdoni.admin.steps.credits") %>
+    </p>
+  </div>
+  <%= link_to "#", class: "button primary js-vocdoni-credits-collect-faucet-tokens" do %>
+    <%= icon "euro", role: "img", "aria-hidden": true %>&nbsp;
+    <%= t("get_more", scope: "decidim.vocdoni.admin.steps.credits") %>
+  <% end %>
+</div>

--- a/app/views/decidim/vocdoni/admin/steps/_canceled.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_canceled.html.erb
@@ -1,0 +1,13 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t("title", scope: "decidim.vocdoni.admin.steps.canceled") %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="callout alert">
+      <p><%= t("message", scope: "decidim.vocdoni.admin.steps.canceled") %></p>
+    </div>
+
+    <%= render partial: "action_buttons", locals: { election: election } %>
+  </div>
+</div>

--- a/app/views/decidim/vocdoni/admin/steps/_create_election.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_create_election.html.erb
@@ -16,14 +16,6 @@
     </div>
 
     <ul class="no-bullet-indented">
-      <p class="label secondary">
-      <%= icon "credit-card", role: "img", "aria-hidden": true %>&nbsp;
-      <%= t("credits", scope: "decidim.vocdoni.admin.steps.create_election") %>:&nbsp;
-      <span class="js-vocdoni-balance-credits">
-        <span class="loading-spinner"></span>
-      </span>
-      </p>
-
       <% form.messages.each do |key, value| %>
         <% if form.errors.include?(key) %>
           <li><%= icon "x", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>

--- a/app/views/decidim/vocdoni/admin/steps/_create_election.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_create_election.html.erb
@@ -11,8 +11,18 @@
     <%= f.hidden_field :vocdoni_election_id %>
 
     <div class="js-election-create-error-message callout alert hide">
-      <h3 class="h5"><%= t("failed.title", scope: "decidim.vocdoni.admin.steps.create_election") %></h2>
+      <h3 class="h5"><%= t("failed.title", scope: "decidim.vocdoni.admin.steps.create_election") %></h3>
       <p><%= t("failed.message", scope: "decidim.vocdoni.admin.steps.create_election") %></p>
+      <div data-accordion data-multi-expand="true" data-allow-all-closed="true">
+        <dl class="voc-accordion accordion" data-accordion data-multi-expand="true" data-allow-all-closed="true">
+          <dd class="accordion-item" data-accordion-item>
+            <a href="#" class="accordion-title"><%= t("failed.details", scope: "decidim.vocdoni.admin.steps.create_election") %></a>
+            <div class="accordion-content" data-tab-content>
+              <pre class="js-election-create-error-message-details"></pre>
+            </div>
+          </dd>
+        </dl>
+      </div>
     </div>
 
     <ul class="no-bullet-indented">

--- a/app/views/decidim/vocdoni/admin/steps/_danger_zone.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_danger_zone.html.erb
@@ -1,0 +1,20 @@
+<% if election.election_type.fetch("interruptible") %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title"><%= t("title", scope: "decidim.vocdoni.admin.steps.danger_zone") %></h2>
+    </div>
+
+    <%= f.hidden_field :status %>
+
+    <div class="card-section callout alert">
+      <p><%= t("message", scope: "decidim.vocdoni.admin.steps.danger_zone") %></p>
+
+      <% [["continue", "success"], ["pause", "warning"], ["cancel", "alert"], ["end", "alert"]].each do |action, button_class| %>
+        <%= f.submit t(action, scope: "decidim.vocdoni.admin.steps.danger_zone.action"),
+          class: "button #{button_class} js-vocdoni-interruptible hide",
+          data: { action: action, confirm: t("confirm",  scope: "decidim.vocdoni.admin.steps.danger_zone") } %>
+    <% end %>
+    <span></span>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/vocdoni/admin/steps/_paused.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_paused.html.erb
@@ -1,10 +1,12 @@
 <div class="card">
   <div class="card-divider">
-    <h2 class="card-title"><%= t("title", scope: "decidim.vocdoni.admin.steps.vote") %></h2>
+    <h2 class="card-title"><%= t("title", scope: "decidim.vocdoni.admin.steps.paused") %></h2>
   </div>
 
   <div class="card-section">
-    <p><%= t("message", scope: "decidim.vocdoni.admin.steps.vote", end_time: election.end_time) %></p>
+    <div class="callout warning">
+      <p><%= t("message", scope: "decidim.vocdoni.admin.steps.paused") %></p>
+    </div>
 
     <% if election.election_type.fetch("secret_until_the_end") %>
       <p><%= t("secret_until_the_end", scope: "decidim.vocdoni.admin.steps.vote") %></p>
@@ -18,4 +20,4 @@
   <%= render(partial: "vote_stats", locals: { polling: "true" }) %>
 <% end %>
 
-<%= render partial: "danger_zone", locals: { election: election, f: f } %>
+<%= render partial: "partials/danger_zone", local: { election: election, f: f } %>

--- a/app/views/decidim/vocdoni/admin/steps/_paused.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_paused.html.erb
@@ -20,4 +20,4 @@
   <%= render(partial: "vote_stats", locals: { polling: "true" }) %>
 <% end %>
 
-<%= render partial: "partials/danger_zone", local: { election: election, f: f } %>
+<%= render partial: "danger_zone", locals: { election: election, f: f } %>

--- a/app/views/decidim/vocdoni/admin/steps/_results_published.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_results_published.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <div class="card-section table-scroll">
-    <ul class="voc-accordion mb-m evote__preview"
+    <ul class="voc-accordion accordion mb-m evote__preview"
         data-accordion
         data-multi-expand="true"
         data-allow-all-closed="true">

--- a/app/views/decidim/vocdoni/admin/steps/_vote_ended.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_vote_ended.html.erb
@@ -19,7 +19,7 @@
     <% question.answers.each do |answer| %>
       <%= f.fields_for "results[]", answer do |result_form| %>
         <%= result_form.number_field :id %>
-        <%= result_form.number_field :votes, "data-question-idx" => idx, "data-answer-id" => answer.id, value: 0 %>
+        <%= result_form.number_field :votes, "data-question-idx" => idx, "data-answer-id" => answer.id, "data-answer-value" => answer.value, value: 0 %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/decidim/vocdoni/admin/steps/_vote_stats.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/_vote_stats.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <div class="card-section table-scroll">
-    <ul class="voc-accordion mb-m evote__preview js-votes-count"
+    <ul class="voc-accordion accordion mb-m evote__preview js-votes-count"
         data-wallet="<%= @current_vocdoni_wallet.private_key %>"
         data-vocdoni-env="<%= Decidim::Vocdoni.config.api_endpoint_env %>"
         data-election-unique-id="<%= @election.vocdoni_election_id %>"

--- a/app/views/decidim/vocdoni/admin/steps/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/index.html.erb
@@ -22,6 +22,8 @@
       <span class="<%= step.last %>"><%= t("steps.#{step.first}.title", scope: "decidim.vocdoni.admin") %></span>
     <% end %>
   </div>
+
+  <%= render partial: "available_credits" %>
 </div>
 
 <% if @form %>

--- a/app/views/decidim/vocdoni/admin/steps/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/index.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(election.title)) %>
+<% add_decidim_page_title(t(".title")) %>
+
 <div class="card js-vocdoni-client"
   data-default-locale="<%= current_organization.default_locale %>"
   data-vocdoni-wallet-private-key="<%= @current_vocdoni_wallet.private_key %>"

--- a/app/views/decidim/vocdoni/admin/steps/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/index.html.erb
@@ -3,6 +3,7 @@
 
 <div class="card js-vocdoni-client"
   data-default-locale="<%= current_organization.default_locale %>"
+  data-answers-values-election-path=<%= answers_values_election_path(election) %>
   data-vocdoni-wallet-private-key="<%= @current_vocdoni_wallet.private_key %>"
   <% if @election.vocdoni_election_id %>
     data-vocdoni-election-id="<%= @election.vocdoni_election_id %>"

--- a/app/views/decidim/vocdoni/admin/steps/index.html.erb
+++ b/app/views/decidim/vocdoni/admin/steps/index.html.erb
@@ -3,7 +3,7 @@
 
 <div class="card js-vocdoni-client"
   data-default-locale="<%= current_organization.default_locale %>"
-  data-answers-values-election-path=<%= answers_values_election_path(election) %>
+  data-answers-values-election-path="<%= answers_values_election_path(election) %>"
   data-vocdoni-wallet-private-key="<%= @current_vocdoni_wallet.private_key %>"
   <% if @election.vocdoni_election_id %>
     data-vocdoni-election-id="<%= @election.vocdoni_election_id %>"

--- a/app/views/decidim/vocdoni/admin/wallets/new.html.erb
+++ b/app/views/decidim/vocdoni/admin/wallets/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <%= decidim_form_for(@form, html: { class: "form new_wallet" }) do |f| %>
   <%= render partial: "form", object: f, locals: { title: t(".title") } %>
 

--- a/app/views/decidim/vocdoni/elections/show.html.erb
+++ b/app/views/decidim/vocdoni/elections/show.html.erb
@@ -45,7 +45,7 @@ edit_link(
   <% end %>
   <div class="columns medium-8 mediumlarge-7">
     <div class="section">
-      <p><%= decidim_sanitize_editor(simple_format(translated_attribute(election.description)), strip_tags: true) %></p>
+      <p><%= decidim_sanitize_editor(simple_format(translated_attribute(election.description))) %></p>
 
       <%= cell("decidim/vocdoni/election_vote_cta", election) %>
     </div>

--- a/app/views/decidim/vocdoni/votes/_login.html.erb
+++ b/app/views/decidim/vocdoni/votes/_login.html.erb
@@ -17,6 +17,7 @@
                   <form>
                     <div>
                       <div class="callout alert hide js-login_error"><%= t(".failed") %></div>
+                      <div class="callout warning hide js-election_not_open"><%= t(".election_not_open") %></div>
                     </div>
                     <div>
                       <%= render partial: "login_fields", locals: { f: f } %>

--- a/app/views/decidim/vocdoni/votes/_show_vote_cast_step.html.erb
+++ b/app/views/decidim/vocdoni/votes/_show_vote_cast_step.html.erb
@@ -24,13 +24,21 @@
             </button>
           </div>
         </div>
-        <%= link_to t("verify", scope: "decidim.vocdoni.votes.vote_cast"), "#", class: "verify_ballot", target: "_blank", rel: "noopener noreferrer" %>
+
+        <p>
+          <%= link_to t("verify", scope: "decidim.vocdoni.votes.vote_cast"), "#", class: "verify_ballot", target: "_blank", rel: "noopener noreferrer" %>
+        </p>
+
+        <p>
+          <%= t("or", scope: "decidim.vocdoni.votes.vote_cast") %>
+        </p>
+
+        <%= link_to election_path(election), class: "button" do %>
+          <%= t("exit", scope: "decidim.vocdoni.votes.vote_cast") %>
+        <% end %>
       </p>
     </div>
 
-    <%= link_to election_path(election), class: "button" do %>
-      <%= t("exit", scope: "decidim.vocdoni.votes.vote_cast") %>
-    <% end %>
     <%= render partial: "vocdoni_logo" %>
   </div>
 </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -13,7 +13,7 @@ ignore_unused:
   - "decidim.vocdoni.admin.wallets.ready.title"
   - "decidim.vocdoni.admin_log.election.{create,delete,end_vote,publish,publish_results,setup,start_vote,unpublish,update}"
   - "decidim.vocdoni.admin_log.wallet.create"
-  - "decidim.vocdoni.election_m.badge_name.{finished,ongoing,upcoming}"
+  - "decidim.vocdoni.election_m.badge_name.{finished,ongoing,upcoming,paused,canceled}"
   - "decidim.vocdoni.election_m.questions"
   - "decidim.vocdoni.elections.show.action_button.{change_vote,vote,vote_again}"
   - "decidim.vocdoni.elections.show.preview"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,11 +430,11 @@ en:
           copy_vote_receipt_clarification: Copy vote receipt to clipboard
           copy_vote_receipt_copied: Copied!
           copy_vote_receipt_message: The vote receipt was successfully copied to clipboard.
-          description: Your vote has been cast successfully! You can store the following
-            receipt as proof of your vote's inclusion at any time and check it using
-            the Vocdoni Explorer.
+          description: You can store the following receipt as proof of your vote's
+            inclusion at any time and check it using the Vocdoni Explorer.
           exit: Exit the voting booth
-          header: Vote confirmed
+          header: Your vote has been cast successfully!
+          or: or
           verify: "( Verify my vote )"
           vote_receipt: 'Your vote receipt is:'
         voting_step:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,8 @@ en:
             will_verify: You will be able to verify your vote once the election is
               started.
           voting_period_status:
-            canceled: Voting was canceled. It was ment to begin on %{start_time} and end on %{end_time}
+            canceled: Voting was canceled. It was ment to begin on %{start_time} and
+              end on %{end_time}
             finished: Voting began on %{start_time} and ended on %{end_time}
             ongoing: 'Active voting until: %{end_time}'
             paused: Voting is paused. It ends on %{end_time}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,7 @@ en:
               time_before: The setup is not being done <strong>at least %{minutes}
                 minutes</strong> before the election starts. <a href=%{link}>Fix it</a>.
             failed:
+              details: View details
               message: Check the Web Development console log error message, fix the
                 problem and retry.
               title: The election has an error and couldn't be created

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,8 +168,12 @@ en:
             invalid: There was a problem updating this question
             success: Question successfully updated
         steps:
+          credits:
+            available: Available credits
+            get_more: Get more credits
+            warning: You have no credits left. You can get more credits by clicking
+              on the button below.
           create_election:
-            credits: Available credits
             description: Your voting process is secured using the advanced digital
               voting technology of the Vocdoni Protocol. Please be patient, as the
               set-up process may take some time.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -388,6 +388,8 @@ en:
         login:
           access: Access
           description: To vote, we'll need to check that you're on the census
+          election_not_open: Currently the election is not open for voting. Try again
+            later.
           failed: Check that the provided data is correct and try again
           form_title: Enter your data
           title: Verify your identity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
       election:
         description: Description
         end_time: End time
-        interruptible: Interruptible
         secret_until_the_end: Secret until the end
         start_time: Start time
         stream_uri: Video stream link
@@ -168,6 +167,10 @@ en:
             invalid: There was a problem updating this question
             success: Question successfully updated
         steps:
+          canceled:
+            message: This election has been canceled prematurely. There aren't any
+              results.
+            title: Canceled
           credits:
             available: Available credits
             get_more: Get more credits
@@ -210,12 +213,25 @@ en:
             explorer_vote: View at Explorer Vote
             message: The election has been created. We're waiting for the start date
               time to arrive.
-            secret_until_the_end: The election results will be secret until the end
-              of the voting period.
             title: Election created
             view: View landing page
+          danger_zone:
+            action:
+              cancel: Cancel
+              continue: Continue
+              end: End
+              pause: Pause
+            confirm: Are you sure you want to do this action?
+            message: The election can be interrupted
+            title: Danger zone
+          ended:
+            title: Ended
           index:
             title: Steps dashboard
+          paused:
+            message: The election is paused
+            success: The election has been successfully continued.
+            title: Paused
           powered_by_html: This module makes use of Vocdoni Protocol, an open-source
             voting technology to organize elections<br>with the highest standards
             of security, universal verifiability, censorship-resistance, and anonymity.
@@ -229,6 +245,9 @@ en:
             title: Results published
           vote:
             message: We're on the vote period until %{end_time}.
+            secret_until_the_end: The election results will be secret until the end
+              of the voting period.
+            success: The election has been successfully paused.
             title: Vote period
           vote_ended:
             error:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,7 @@ en:
             name: question
         questions:
           create:
-            election_started: The election has already started
+            election_ongoing: The election has already started and it's blocked
             invalid: There was a problem creating this question
             success: Question successfully created
           destroy:
@@ -297,8 +297,10 @@ en:
           create: "%{user_name} created the Organization wallet for the Vocdoni API"
       election_m:
         badge_name:
+          canceled: Canceled
           finished: Finished
           ongoing: Active
+          paused: Paused
           upcoming: Upcoming
         end_date: Ends
         footer:
@@ -321,7 +323,7 @@ en:
             other: "%{count} elections"
         preview:
           available_answers: 'Available answers:'
-          description: 'These are the questions you will find in the voting process:'
+          description: 'These are the questions for this voting process:'
           title: Election questions
         results:
           description: 'These are the results of the voting, for each question:'
@@ -346,8 +348,10 @@ en:
             will_verify: You will be able to verify your vote once the election is
               started.
           voting_period_status:
+            canceled: Voting was canceled. It was ment to begin on %{start_time} and end on %{end_time}
             finished: Voting began on %{start_time} and ended on %{end_time}
             ongoing: 'Active voting until: %{end_time}'
+            paused: Voting is paused. It ends on %{end_time}
             upcoming: Voting begins on %{start_time}
       models:
         answer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,11 +171,6 @@ en:
             message: This election has been canceled prematurely. There aren't any
               results.
             title: Canceled
-          credits:
-            available: Available credits
-            get_more: Get more credits
-            warning: You have no credits left. You can get more credits by clicking
-              on the button below.
           create_election:
             description: Your voting process is secured using the advanced digital
               voting technology of the Vocdoni Protocol. Please be patient, as the
@@ -215,6 +210,11 @@ en:
               time to arrive.
             title: Election created
             view: View landing page
+          credits:
+            available: Available credits
+            get_more: Get more credits
+            warning: You have no credits left. You can get more credits by clicking
+              on the button below.
           danger_zone:
             action:
               cancel: Cancel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,8 +107,6 @@ en:
               href="%{steps_path}">ready to setup</a>.
             title: Current census data
         elections:
-          answers_values:
-            success: The answers values have been successfully updated.
           create:
             invalid: There was a problem creating this election
             success: Election successfully created
@@ -176,8 +174,6 @@ en:
               voting technology of the Vocdoni Protocol. Please be patient, as the
               set-up process may take some time.
             errors:
-              answers_have_values: All the answers must have a value. <a href=%{link}
-                data-method="post">Fix it</a>.
               census_ready: The census is <strong>not ready</strong>. <a href=%{link}>Fix
                 it</a>.
               minimum_answers: Questions must have <strong>at least two answers</strong>.
@@ -194,7 +190,6 @@ en:
               title: The election has an error and couldn't be created
             invalid: There was a problem setting up this election
             requirements:
-              answers_have_values: All the answers have a <strong>value</strong>.
               census_ready: The census is <strong>ready</strong>.
               minimum_answers: Each question has <strong>at least two answers</strong>.
               minimum_questions: The election has <strong>at least one question</strong>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,7 +390,7 @@ en:
           confirm: Confirm your vote
           failed: Vote failed
           login: Identification
-          submitting: Subtmitting the vote
+          submitting: Submitting the vote
           vote_cast: Your vote has been cast
         login:
           access: Access

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       election:
         description: Description
         end_time: End time
+        interruptible: Interruptible
         secret_until_the_end: Secret until the end
         start_time: Start time
         stream_uri: Video stream link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -337,6 +337,8 @@ en:
             vote: Start voting
             vote_again: Vote again
           back: Available elections
+          canceled: This election was canceled
+          paused: This election is curently paused. Try again later.
           preview: Preview
           verify:
             already_voted: Already voted?

--- a/lib/decidim/api/vocdoni_answer_type.rb
+++ b/lib/decidim/api/vocdoni_answer_type.rb
@@ -14,7 +14,7 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "The title for this answer", null: false
       field :description, Decidim::Core::TranslatedFieldType, "The description for this answer", null: true
       field :weight, GraphQL::Types::Int, "The ordering weight for this answer", null: true
-      field :value, GraphQL::Types::Int, "The internal value of this answer", null: false
+      field :value, GraphQL::Types::Int, "The internal value of this answer", null: true
 
       # field :results, [Decidim::Vocdoni::VocdoniResultType, { null: true }], "The voting results related to this answer", null: true
     end

--- a/lib/decidim/api/vocdoni_election_type.rb
+++ b/lib/decidim/api/vocdoni_election_type.rb
@@ -25,10 +25,15 @@ module Decidim
       field :published_at, Decidim::Core::DateTimeType, "When this election was published", null: true
       field :blocked, GraphQL::Types::Boolean, "Whether this election has it's parameters blocked or not", method: :blocked?, null: true
       field :status, GraphQL::Types::String, "The status for this election", null: true, camelize: false
-      field :secret_until_the_end, GraphQL::Types::Boolean, "Whether this election will have the votes secret until the end of it", null: true
+      field :interruptible, GraphQL::Types::Boolean, "Whether this election has have the 'interruptible' setting enabled", null: true
+      field :secret_until_the_end, GraphQL::Types::Boolean, "Whether this election has the 'votes secret until the end' setting enabled", null: true
 
       field :questions, [Decidim::Vocdoni::VocdoniQuestionType, { null: true }], "The questions for this election", null: false
       field :voters, [Decidim::Vocdoni::VocdoniVoterType, { null: true }], "The voters for this election", null: false
+
+      def interruptible
+        object.election_type.fetch("interruptible")
+      end
 
       def secret_until_the_end
         object.election_type.fetch("secret_until_the_end")

--- a/lib/decidim/vocdoni.rb
+++ b/lib/decidim/vocdoni.rb
@@ -20,7 +20,7 @@ module Decidim
     # Public Setting to configure the Vocdoni API enpoint
     # It can be "dev" or "stg"
     config_accessor :api_endpoint_env do
-      "dev"
+      "stg"
     end
 
     def self.explorer_vote_domain

--- a/lib/decidim/vocdoni/election_status_changer.rb
+++ b/lib/decidim/vocdoni/election_status_changer.rb
@@ -32,12 +32,14 @@ module Decidim
       end
 
       def update_elections_status(elections, status)
+        # rubocop:disable Rails/Output
         if elections.count.zero?
-          Rails.logger.debug { "No elections to change to '#{status}' status" } unless quiet
+          puts "No elections to change to '#{status}' status" unless quiet
           return
         end
 
-        Rails.logger.debug { "Changing #{elections.count} election to '#{status}' status" } unless quiet
+        puts "Changing #{elections.count} election to '#{status}' status" unless quiet
+        # rubocop:enable Rails/Output
         # rubocop:disable Rails/SkipsModelValidations
         elections.update_all(status: status)
         # rubocop:enable Rails/SkipsModelValidations

--- a/lib/decidim/vocdoni/election_status_changer.rb
+++ b/lib/decidim/vocdoni/election_status_changer.rb
@@ -3,6 +3,10 @@
 module Decidim
   module Vocdoni
     class ElectionStatusChanger
+      def initialize(quiet: true)
+        @quiet = quiet
+      end
+
       def run
         update_ongoing_elections!
         update_finished_elections!
@@ -10,22 +14,32 @@ module Decidim
 
       private
 
+      attr_reader :quiet
+
       def update_ongoing_elections!
-        # rubocop:disable Rails/SkipsModelValidations
-        Decidim::Vocdoni::Election
-          .where(status: "created")
-          .where("start_time <= ?", Time.zone.now)
-          .where("end_time >= ?", Time.zone.now)
-          &.update_all(status: "vote")
-        # rubocop:enable Rails/SkipsModelValidations
+        elections = Decidim::Vocdoni::Election
+                    .where(status: "created")
+                    .where("start_time <= ?", Time.zone.now)
+                    .where("end_time >= ?", Time.zone.now)
+        update_elections_status(elections, "vote")
       end
 
       def update_finished_elections!
+        elections = Decidim::Vocdoni::Election
+                    .where(status: %w(created vote))
+                    .where("end_time <= ?", Time.zone.now)
+        update_elections_status(elections, "vote_ended")
+      end
+
+      def update_elections_status(elections, status)
+        if elections.count.zero?
+          Rails.logger.debug { "No elections to change to '#{status}' status" } unless quiet
+          return
+        end
+
+        Rails.logger.debug { "Changing #{elections.count} election to '#{status}' status" } unless quiet
         # rubocop:disable Rails/SkipsModelValidations
-        Decidim::Vocdoni::Election
-          .where(status: %w(created vote))
-          .where("end_time <= ?", Time.zone.now)
-          &.update_all(status: "vote_ended")
+        elections.update_all(status: status)
         # rubocop:enable Rails/SkipsModelValidations
       end
     end

--- a/lib/decidim/vocdoni/election_status_changer.rb
+++ b/lib/decidim/vocdoni/election_status_changer.rb
@@ -3,18 +3,12 @@
 module Decidim
   module Vocdoni
     class ElectionStatusChanger
-      def initialize(quiet: true)
-        @quiet = quiet
-      end
-
       def run
         update_ongoing_elections!
         update_finished_elections!
       end
 
       private
-
-      attr_reader :quiet
 
       def update_ongoing_elections!
         elections = Decidim::Vocdoni::Election
@@ -34,11 +28,11 @@ module Decidim
       def update_elections_status(elections, status)
         # rubocop:disable Rails/Output
         if elections.count.zero?
-          puts "No elections to change to '#{status}' status" unless quiet
+          puts "No elections to change to '#{status}' status"
           return
         end
 
-        puts "Changing #{elections.count} election to '#{status}' status" unless quiet
+        puts "Changing #{elections.count} election to '#{status}' status"
         # rubocop:enable Rails/Output
         # rubocop:disable Rails/SkipsModelValidations
         elections.update_all(status: status)

--- a/lib/decidim/vocdoni/test/factories.rb
+++ b/lib/decidim/vocdoni/test/factories.rb
@@ -174,7 +174,6 @@ FactoryBot.define do
     title { generate_localized_title }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     weight { Faker::Number.number(digits: 1) }
-    value { Faker::Number.number(digits: 1) }
 
     trait :with_photos do
       transient do

--- a/lib/decidim/vocdoni/test/factories.rb
+++ b/lib/decidim/vocdoni/test/factories.rb
@@ -40,10 +40,12 @@ FactoryBot.define do
     end
 
     trait :started do
+      status { "vote" }
       start_time { 2.days.ago }
     end
 
     trait :ongoing do
+      blocked_at { Time.current }
       started
     end
 
@@ -64,6 +66,7 @@ FactoryBot.define do
     end
 
     trait :finished do
+      status { "vote_ended" }
       started
       complete
       end_time { 1.day.ago }

--- a/lib/decidim/vocdoni/test/factories.rb
+++ b/lib/decidim/vocdoni/test/factories.rb
@@ -74,6 +74,18 @@ FactoryBot.define do
       published_at { Time.current }
     end
 
+    trait :paused do
+      published
+
+      status { "paused" }
+    end
+
+    trait :canceled do
+      published
+
+      status { "canceled" }
+    end
+
     trait :simple do
       after(:build) do |election, _evaluator|
         election.questions << build(:vocdoni_question, :simple, election: election, weight: 1)

--- a/lib/decidim/vocdoni/test/factories.rb
+++ b/lib/decidim/vocdoni/test/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     status { nil }
     election_type do
       {
+        "interruptible" => true,
         "secret_until_the_end" => false
       }
     end

--- a/lib/tasks/decidim_vocdoni.rake
+++ b/lib/tasks/decidim_vocdoni.rake
@@ -4,8 +4,7 @@ require "decidim/vocdoni/election_status_changer"
 
 namespace :decidim_vocdoni do
   desc "Change election status automatically in Vocdoni's component"
-  task :change_election_status, [:quiet] => :environment do |_task, args|
-    quiet = args[:quiet] == "quiet"
-    Decidim::Vocdoni::ElectionStatusChanger.new(quiet: quiet).run
+  task :change_election_status, [] => :environment do
+    Decidim::Vocdoni::ElectionStatusChanger.new.run
   end
 end

--- a/lib/tasks/decidim_vocdoni.rake
+++ b/lib/tasks/decidim_vocdoni.rake
@@ -4,7 +4,8 @@ require "decidim/vocdoni/election_status_changer"
 
 namespace :decidim_vocdoni do
   desc "Change election status automatically in Vocdoni's component"
-  task :change_election_status, [] => :environment do
-    Decidim::Vocdoni::ElectionStatusChanger.new.run
+  task :change_election_status, [:quiet] => :environment do |_task, args|
+    quiet = args[:quiet] == "quiet"
+    Decidim::Vocdoni::ElectionStatusChanger.new(quiet: quiet).run
   end
 end

--- a/spec/cells/decidim/vocdoni/election_m_cell_spec.rb
+++ b/spec/cells/decidim/vocdoni/election_m_cell_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::Vocdoni::ElectionMCell, type: :cell do
   let(:cell_html) { my_cell.call }
   let(:start_time) { 2.days.ago }
   let(:end_time) { 1.day.from_now }
-  let!(:election) { create(:vocdoni_election, :published, start_time: start_time, end_time: end_time) }
+  let!(:election) { create(:vocdoni_election, :ongoing, start_time: start_time, end_time: end_time) }
   let(:model) { election }
   let(:user) { create :user, organization: election.participatory_space.organization }
 

--- a/spec/commands/decidim/vocdoni/admin/create_answer_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/create_answer_spec.rb
@@ -64,8 +64,8 @@ describe Decidim::Vocdoni::Admin::CreateAnswer do
     end
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/commands/decidim/vocdoni/admin/create_question_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/create_question_spec.rb
@@ -62,11 +62,11 @@ describe Decidim::Vocdoni::Admin::CreateQuestion do
     end
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
-      expect { subject.call }.to broadcast(:election_started)
+      expect { subject.call }.to broadcast(:election_ongoing)
     end
   end
 end

--- a/spec/commands/decidim/vocdoni/admin/destroy_answer_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/destroy_answer_spec.rb
@@ -28,8 +28,8 @@ describe Decidim::Vocdoni::Admin::DestroyAnswer do
     expect(action_log.version.event).to eq "destroy"
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/commands/decidim/vocdoni/admin/destroy_election_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/destroy_election_spec.rb
@@ -25,8 +25,8 @@ describe Decidim::Vocdoni::Admin::DestroyElection do
     expect(action_log.version.event).to eq "destroy"
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/commands/decidim/vocdoni/admin/destroy_question_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/destroy_question_spec.rb
@@ -26,8 +26,8 @@ describe Decidim::Vocdoni::Admin::DestroyQuestion do
     expect(action_log.version.event).to eq "destroy"
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/commands/decidim/vocdoni/admin/update_answer_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/update_answer_spec.rb
@@ -51,8 +51,8 @@ describe Decidim::Vocdoni::Admin::UpdateAnswer do
     end
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/commands/decidim/vocdoni/admin/update_election_status_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/update_election_status_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Vocdoni::Admin::UpdateElectionStatus do
+  subject { described_class.new(form) }
+
+  let(:election) { create :vocdoni_election }
+  let(:organization) { election.component.organization }
+  let(:user) { create :user, :admin, :confirmed, organization: organization }
+  let(:form) do
+    double(
+      invalid?: invalid,
+      current_user: user,
+      status: "paused",
+      election: election
+    )
+  end
+  let(:invalid) { false }
+
+  it "updates the election" do
+    subject.call
+    expect(election.status).to eq "paused"
+  end
+
+  it "traces the action", versioning: true do
+    expect(Decidim.traceability)
+      .to receive(:perform_action!)
+      .with(:change_election_status, election, user)
+      .and_call_original
+
+    expect { subject.call }.to change(Decidim::ActionLog, :count)
+    action_log = Decidim::ActionLog.last
+    expect(action_log.version).to be_present
+  end
+
+  context "when the form is not valid" do
+    let(:invalid) { true }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+end

--- a/spec/commands/decidim/vocdoni/admin/update_question_spec.rb
+++ b/spec/commands/decidim/vocdoni/admin/update_question_spec.rb
@@ -48,8 +48,8 @@ describe Decidim::Vocdoni::Admin::UpdateQuestion do
     end
   end
 
-  context "when the election has started" do
-    let(:election) { create :vocdoni_election, :started }
+  context "when the election is ongoing" do
+    let(:election) { create :vocdoni_election, :ongoing }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/spec/forms/decidim/vocdoni/admin/election_status_form_spec.rb
+++ b/spec/forms/decidim/vocdoni/admin/election_status_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Vocdoni::Admin::ElectionStatusForm do
+  subject { described_class.from_params(attributes).with_context(context) }
+
+  let(:election) { create(:vocdoni_election, :ongoing) }
+  let(:status) { "paused" }
+  let(:context) do
+    {
+      election: election
+    }
+  end
+  let(:attributes) do
+    {
+      status: status
+    }
+  end
+
+  it { is_expected.to be_valid }
+
+  describe "when the election isn't interruptible" do
+    let(:election) { create(:vocdoni_election, :ongoing, election_type: { interruptible: false }) }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when the election's status doesn't exist" do
+    let(:status) { "invalid" }
+
+    it { is_expected.not_to be_valid }
+  end
+end

--- a/spec/forms/decidim/vocdoni/admin/setup_form_spec.rb
+++ b/spec/forms/decidim/vocdoni/admin/setup_form_spec.rb
@@ -69,7 +69,7 @@ describe Decidim::Vocdoni::Admin::SetupForm do
 
   context "when the setup_minimum_minutes_before_start is different" do
     before do
-      allow(Decidim::Vocdoni).to receive(:setup_minimum_minutes_before_start).and_return(33)
+      allow(Decidim::Vocdoni.config).to receive(:setup_minimum_minutes_before_start).and_return(33)
     end
 
     it "shows the message" do

--- a/spec/helpers/decidim/vocdoni/admin/steps_helper_spec.rb
+++ b/spec/helpers/decidim/vocdoni/admin/steps_helper_spec.rb
@@ -45,5 +45,33 @@ describe Decidim::Vocdoni::Admin::StepsHelper do
                               ])
       }
     end
+
+    context "when current_step is paused" do
+      let(:current_step) { "paused" }
+
+      it {
+        expect(subject).to eq([
+                                ["create_election", "text-success"],
+                                ["created", "text-success"],
+                                ["vote", "text-success"],
+                                ["paused", "text-warning"],
+                                ["vote_ended", "text-muted"],
+                                ["results_published", "text-muted"]
+                              ])
+      }
+    end
+
+    context "when current_step is canceled" do
+      let(:current_step) { "canceled" }
+
+      it {
+        expect(subject).to eq([
+                                ["create_election", "text-success"],
+                                ["created", "text-success"],
+                                ["vote", "text-success"],
+                                ["canceled", "text-warning"]
+                              ])
+      }
+    end
   end
 end

--- a/spec/lib/decidim/vocdoni/election_status_changer_spec.rb
+++ b/spec/lib/decidim/vocdoni/election_status_changer_spec.rb
@@ -24,10 +24,10 @@ describe Decidim::Vocdoni::ElectionStatusChanger do
     end
 
     context "when the elections don't have any status" do
-      let(:new_election) { create(:vocdoni_election) }
-      let(:upcoming_election) { create(:vocdoni_election, :upcoming) }
-      let(:ongoing_election) { create(:vocdoni_election, :ongoing) }
-      let(:finished_election) { create(:vocdoni_election, :finished) }
+      let(:new_election) { create(:vocdoni_election, status: nil) }
+      let(:upcoming_election) { create(:vocdoni_election, :upcoming, status: nil) }
+      let(:ongoing_election) { create(:vocdoni_election, :ongoing, status: nil) }
+      let(:finished_election) { create(:vocdoni_election, :finished, status: nil) }
 
       it "don't change any status" do
         expect(new_election.reload.status).to be_nil

--- a/spec/models/decidim/vocdoni/election_spec.rb
+++ b/spec/models/decidim/vocdoni/election_spec.rb
@@ -30,6 +30,14 @@ describe Decidim::Vocdoni::Election do
     it { is_expected.to be_started }
     it { is_expected.to be_ongoing }
     it { is_expected.not_to be_finished }
+
+    context "and it doesn't have a status" do
+      subject(:election) { build :vocdoni_election, :finished, status: nil }
+
+      it { is_expected.not_to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.not_to be_finished }
+    end
   end
 
   context "when it is finished" do
@@ -38,6 +46,14 @@ describe Decidim::Vocdoni::Election do
     it { is_expected.to be_started }
     it { is_expected.not_to be_ongoing }
     it { is_expected.to be_finished }
+
+    context "and it doesn't have a status" do
+      subject(:election) { build :vocdoni_election, :finished, status: nil }
+
+      it { is_expected.not_to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.not_to be_finished }
+    end
   end
 
   describe "start time checks" do

--- a/spec/models/decidim/vocdoni/election_spec.rb
+++ b/spec/models/decidim/vocdoni/election_spec.rb
@@ -47,12 +47,54 @@ describe Decidim::Vocdoni::Election do
     it { is_expected.not_to be_ongoing }
     it { is_expected.to be_finished }
 
+    context "and it has the old status" do
+      subject(:election) { build :vocdoni_election, :finished, status: "vote" }
+
+      it { is_expected.to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.to be_finished }
+    end
+
     context "and it doesn't have a status" do
       subject(:election) { build :vocdoni_election, :finished, status: nil }
 
       it { is_expected.not_to be_started }
       it { is_expected.not_to be_ongoing }
       it { is_expected.not_to be_finished }
+    end
+  end
+
+  describe "with different status" do
+    context "when it is paused" do
+      subject(:election) { build :vocdoni_election, :started, :paused }
+
+      it { is_expected.not_to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.not_to be_finished }
+    end
+
+    context "when it is canceled" do
+      subject(:election) { build :vocdoni_election, :started, :canceled }
+
+      it { is_expected.to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.to be_finished }
+    end
+
+    context "when it is vote_ended" do
+      subject(:election) { build :vocdoni_election, :started, status: "vote_ended" }
+
+      it { is_expected.to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.to be_finished }
+    end
+
+    context "when it is results_published" do
+      subject(:election) { build :vocdoni_election, :started, status: "results_published" }
+
+      it { is_expected.to be_started }
+      it { is_expected.not_to be_ongoing }
+      it { is_expected.to be_finished }
     end
   end
 

--- a/spec/models/decidim/vocdoni/voter_spec.rb
+++ b/spec/models/decidim/vocdoni/voter_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Vocdoni::Voter do
+  subject(:voter) { build :vocdoni_voter }
+
+  let(:election) { create :vocdoni_election }
+
+  describe ".insert_all" do
+    let(:values) do
+      [
+        ["user1@example.org", "2000-01-01"],
+        ["user2@example.org", "2001-01-01"]
+      ]
+    end
+
+    before do
+      # rubocop:disable Rails/SkipsModelValidations
+      Decidim::Vocdoni::Voter.insert_all(election, values)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    it "creates the voters" do
+      voter1 = Decidim::Vocdoni::Voter.first
+      expect(voter1.email).to eq "user1@example.org"
+      expect(voter1.born_at).to eq Date.parse("2000-01-01")
+      expect(voter1.election).to eq election
+
+      voter2 = Decidim::Vocdoni::Voter.second
+      expect(voter2.email).to eq "user2@example.org"
+      expect(voter2.born_at).to eq Date.parse("2001-01-01")
+      expect(voter2.election).to eq election
+    end
+
+    context "when the email isn't lowercase" do
+      let(:values) do
+        [
+          ["USER1@example.org", "2000-01-01"]
+        ]
+      end
+
+      it "is normalized" do
+        expect(Decidim::Vocdoni::Voter.first.email).to eq("user1@example.org")
+      end
+    end
+  end
+end

--- a/spec/permissions/decidim/vocdoni/permissions_spec.rb
+++ b/spec/permissions/decidim/vocdoni/permissions_spec.rb
@@ -124,6 +124,18 @@ describe Decidim::Vocdoni::Permissions do
       end
     end
 
+    context "when election is paused" do
+      let(:election) { create :vocdoni_election, :paused, component: elections_component }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when election is canceled" do
+      let(:election) { create :vocdoni_election, :canceled, component: elections_component }
+
+      it { is_expected.to be_falsey }
+    end
+
     context "when election has finished" do
       let(:election) { create :vocdoni_election, :published, :finished, component: elections_component }
 

--- a/spec/shared/vote_examples.rb
+++ b/spec/shared/vote_examples.rb
@@ -88,7 +88,6 @@ def uses_the_voting_booth(census_data)
 
   # confirmed vote page
   sleep 2 # wait for the setTimeout in preview
-  expect(page).to have_content("Vote confirmed")
   expect(page).to have_content("Your vote has been cast successfully")
 end
 

--- a/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
+++ b/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
@@ -31,7 +31,6 @@ describe "Admin manages election steps", :slow, type: :system do
         expect(page).to have_content("Processing...")
       end
 
-      expect(page.text).to match(/Available credits:  \d\d/)
       expect(page).to have_admin_callout("successfully")
 
       within ".content.created" do

--- a/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
+++ b/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 describe "Admin manages election steps", :slow, type: :system do
   let(:manifest_name) { :vocdoni }
   let(:current_component) { create :vocdoni_component }
-  let!(:wallet) { create :wallet, organization: current_component.organization, private_key: "0x42a1c49e5b72a2fb146b9aa7c4c520eadc7e97dd885ce857141ba7f2e2d58051" }
 
   include_context "when managing a component as an admin"
 
@@ -14,6 +13,10 @@ describe "Admin manages election steps", :slow, type: :system do
 
     it "performs the action successfully" do
       visit_steps_page
+
+      expect(page).to have_content("It's necessary to create a wallet for this organization")
+      click_button "Create"
+      expect(page).to have_admin_callout("Wallet successfully created")
 
       within "form.create_election" do
         expect(page).to have_content("The election has at least one question.")

--- a/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
+++ b/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
@@ -28,6 +28,7 @@ describe "Admin manages election steps", :slow, type: :system do
         expect(page).to have_content("Processing...")
       end
 
+      expect(page.text).to match(/Available credits:  \d\d/)
       expect(page).to have_admin_callout("successfully")
 
       within ".content.created" do

--- a/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
+++ b/spec/system/decidim/admin/admin_manages_election_steps_spec.rb
@@ -18,6 +18,9 @@ describe "Admin manages election steps", :slow, type: :system do
       click_button "Create"
       expect(page).to have_admin_callout("Wallet successfully created")
 
+      # Wait to let the wallet be created
+      sleep 12
+
       within "form.create_election" do
         expect(page).to have_content("The election has at least one question.")
         expect(page).to have_content("Each question has at least two answers.")

--- a/spec/system/decidim/explore_elections_spec.rb
+++ b/spec/system/decidim/explore_elections_spec.rb
@@ -24,7 +24,7 @@ describe "Explore elections", :slow, type: :system do
 
         expect(page).to have_content("Active voting until")
         expect(page).not_to have_content("All elections")
-        expect(page).to have_content("These are the questions you will find in the voting process")
+        expect(page).to have_content("These are the questions for this voting process")
       end
     end
 

--- a/spec/system/decidim/vote_online_spec.rb
+++ b/spec/system/decidim/vote_online_spec.rb
@@ -49,6 +49,20 @@ describe "Vote online in an election", type: :system do
       it_behaves_like "allows admins to preview the voting booth"
     end
 
+    context "when the election is paused" do
+      let(:election) { create :vocdoni_election, :paused, :simple, component: component }
+
+      it_behaves_like "doesn't allow to vote"
+      it_behaves_like "allows admins to preview the voting booth"
+    end
+
+    context "when the election was canceled" do
+      let(:election) { create :vocdoni_election, :canceled, :simple, component: component }
+
+      it_behaves_like "doesn't allow to vote"
+      it_behaves_like "allows admins to preview the voting booth"
+    end
+
     context "when the election has finished" do
       let(:election) { create :vocdoni_election, :finished, :published, :simple, component: component }
 

--- a/spec/types/decidim/vocdoni/vocdoni_answer_type_spec.rb
+++ b/spec/types/decidim/vocdoni/vocdoni_answer_type_spec.rb
@@ -10,7 +10,7 @@ module Decidim
     describe VocdoniAnswerType, type: :graphql do
       include_context "with a graphql class type"
 
-      let(:model) { create(:vocdoni_election_answer) }
+      let(:model) { create(:vocdoni_election_answer, value: 0) }
 
       it_behaves_like "attachable interface"
 

--- a/spec/types/decidim/vocdoni/vocdoni_election_type_spec.rb
+++ b/spec/types/decidim/vocdoni/vocdoni_election_type_spec.rb
@@ -98,6 +98,14 @@ module Decidim
         end
       end
 
+      describe "interruptible" do
+        let(:query) { "{ interruptible }" }
+
+        it "returns the election's interruptible setting" do
+          expect(response["interruptible"]).to be_truthy
+        end
+      end
+
       describe "secretUntilTheEnd" do
         let(:query) { "{ secretUntilTheEnd }" }
 

--- a/spec/types/integration_schema_spec.rb
+++ b/spec/types/integration_schema_spec.rb
@@ -14,6 +14,7 @@ describe "Decidim::Api::QueryType" do
       "attachments" => [],
       "status" => election.status,
       "blocked" => election.blocked?,
+      "interruptible" => election.election_type.fetch("interruptible"),
       "secretUntilTheEnd" => election.election_type.fetch("secret_until_the_end"),
       "createdAt" => election.created_at.iso8601.to_s.gsub("Z", "+00:00"),
       "description" => { "translation" => election.description[locale] },
@@ -91,6 +92,7 @@ describe "Decidim::Api::QueryType" do
                 status
                 streamUri
                 blocked
+                interruptible
                 secretUntilTheEnd
                 createdAt
                 description {
@@ -167,6 +169,7 @@ describe "Decidim::Api::QueryType" do
           status
           streamUri
           blocked
+          interruptible
           secretUntilTheEnd
           createdAt
           description {

--- a/spec/types/integration_schema_spec.rb
+++ b/spec/types/integration_schema_spec.rb
@@ -37,7 +37,7 @@ describe "Decidim::Api::QueryType" do
               "versions" => [],
               "versionsCount" => 0,
               "weight" => a.weight.to_i,
-              "value" => a.value.to_i
+              "value" => nil
             }
           end,
           "id" => q.id.to_s,


### PR DESCRIPTION
This PR introduces a  setting that configures on the Vocdoni API if the election can be paused, canceled or ended before the `end_time`.

If this checkbox is enabled, then we show a "Danger zone" in the admin panel once the Election is in the "vote" step. This allows the admin to:

* Cancel an election: doesn't publish the results
* End an election: publish the results. It's the same result as if the election has reached the configured end_time.
* Pause an election: momentarily doesn't accept votes

Fixes #46 