### PR TITLE
Replace born_at with token in Voters' census data

### DIFF
--- a/app/forms/decidim/vocdoni/admin/census_credential_form.rb
+++ b/app/forms/decidim/vocdoni/admin/census_credential_form.rb
@@ -9,7 +9,7 @@ module Decidim
         mimic :voter
 
         attribute :email, String
-        attribute :born_at, String
+        attribute :token, String
         attribute :wallet_address, String
 
         validates :wallet_address, presence: true

--- a/app/forms/decidim/vocdoni/login_form.rb
+++ b/app/forms/decidim/vocdoni/login_form.rb
@@ -7,9 +7,7 @@ module Decidim
     # with the SDK
     class LoginForm < Decidim::Form
       attribute :email, String
-      attribute :day, Integer
-      attribute :month, Integer
-      attribute :year, Integer
+      attribute :token, String
     end
   end
 end

--- a/app/models/decidim/vocdoni/answer.rb
+++ b/app/models/decidim/vocdoni/answer.rb
@@ -21,7 +21,7 @@ module Decidim
       # A votes percentage relative to the question
       # Returns a Float.
       def votes_percentage
-        @votes_percentage ||= (votes.to_f / question.total_votes * 100.0).round
+        @votes_percentage ||= (votes.to_f / question.total_votes * 100.0).round(2)
       end
 
       def slug

--- a/app/models/decidim/vocdoni/csv_census/data.rb
+++ b/app/models/decidim/vocdoni/csv_census/data.rb
@@ -30,9 +30,9 @@ module Decidim
 
         def process_row(row)
           user_mail = row.fetch("email", nil)
-          user_born_at = row.fetch("born_at", nil)
-          if mail_valid?(user_mail) && born_at_valid?(user_born_at)
-            values << [user_mail, user_born_at]
+          user_token = row.fetch("token", nil)
+          if mail_valid?(user_mail) && token_valid?(user_token)
+            values << [user_mail, user_token]
           else
             errors << row
           end
@@ -42,8 +42,8 @@ module Decidim
           user_mail.present? && user_mail.match?(::Devise.email_regexp)
         end
 
-        def born_at_valid?(user_born_at)
-          user_born_at.present? # TODO: born_at validation
+        def token_valid?(user_token)
+          user_token.present?
         end
       end
     end

--- a/app/models/decidim/vocdoni/voter.rb
+++ b/app/models/decidim/vocdoni/voter.rb
@@ -6,7 +6,7 @@ module Decidim
       belongs_to :election, foreign_key: "decidim_vocdoni_election_id", class_name: "Decidim::Vocdoni::Election", inverse_of: :voters
 
       validates :email, format: { with: ::Devise.email_regexp }
-      validates :born_at, presence: true
+      validates :token, presence: true
 
       def self.inside(election)
         where(election: election)
@@ -20,7 +20,7 @@ module Decidim
       end
 
       def self.insert_all(election, values)
-        values.each { |value| create(email: value.first.downcase, election: election, born_at: value.second) }
+        values.each { |value| create(email: value.first.downcase, election: election, token: value.second.downcase) }
       end
 
       def self.clear(election)

--- a/app/packs/src/decidim/vocdoni/admin/generate_credentials.js
+++ b/app/packs/src/decidim/vocdoni/admin/generate_credentials.js
@@ -15,9 +15,9 @@ const initializeGenerateCredentialsForm = () => {
 
   const generateWalletOnForm = (credential) => {
     const email = credential.querySelector(".credential_email").value;
-    const bornAt = credential.querySelector(".credential_born_at").value;
+    const token = credential.querySelector(".credential_token").value;
     const walletAddressField = credential.querySelector(".credential_wallet_address");
-    const wallet = VocdoniSDKClient.generateWalletFromData([email, bornAt]);
+    const wallet = VocdoniSDKClient.generateWalletFromData([email, token]);
 
     walletAddressField.value = wallet.address;
   }

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -1,6 +1,9 @@
 import { Election, PlainCensus } from "@vocdoni/sdk";
 import { initVocdoniClient } from "src/decidim/vocdoni/admin/utils/init_vocdoni_client";
 
+// Allow the user to vote multiple times
+const MAX_VOTE_OVERWRITES = -1;
+
 /*
  * Creates an Election in the Vocdoni API
  * Instantiates the Vocdoni SDK client using the Wallet's private key given as parameter.
@@ -138,7 +141,7 @@ export default class CreateVocdoniElection {
         secretUntilTheEnd: electionMetadata.secretUntilTheEnd
       },
       voteType: {
-        maxVoteOverwrites: -1
+        maxVoteOverwrites: MAX_VOTE_OVERWRITES
       }
     });
 

--- a/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
+++ b/app/packs/src/decidim/vocdoni/admin/utils/create_vocdoni_election.js
@@ -136,6 +136,9 @@ export default class CreateVocdoniElection {
       electionType: {
         interruptible: electionMetadata.interruptible,
         secretUntilTheEnd: electionMetadata.secretUntilTheEnd
+      },
+      voteType: {
+        maxVoteOverwrites: -1
       }
     });
 

--- a/app/packs/src/decidim/vocdoni/voter/census-utils.js
+++ b/app/packs/src/decidim/vocdoni/voter/census-utils.js
@@ -35,10 +35,3 @@ export const walletFromLoginForm = ($loginForm) => {
 
   return userWallet;
 }
-
-export const checkIfWalletIsInCensus = async (env, wallet, electionId) => {
-  const client = new VocdoniSDKClient({ env, wallet })
-  client.setElectionId(electionId);
-  const isInCensus = await client.isInCensus();
-  return isInCensus;
-}

--- a/app/packs/src/decidim/vocdoni/voter/census-utils.js
+++ b/app/packs/src/decidim/vocdoni/voter/census-utils.js
@@ -14,40 +14,24 @@ export const walletFromLoginForm = ($loginForm) => {
   }
 
   const email = $loginForm.find("#login_email").val().toLowerCase();
-  let bornAtDay = $loginForm.find("#login_day").val();
-  let bornAtMonth = $loginForm.find("#login_month").val();
-  const bornAtYear = $loginForm.find("#login_year").val();
+  const token = $loginForm.find("#login_token").val().toLowerCase();
 
   if (!email.includes("@")) {
     return {};
   }
 
-  if (bornAtYear.length !== 4) {
-    return {};
-  }
-
-  if (bornAtDay.length === 1) {
-    bornAtDay = `0${bornAtDay}`;
-  }
-
-  if (bornAtMonth.length === 1) {
-    bornAtMonth = `0${bornAtMonth}`;
-  }
-
-  const bornAt = `${bornAtYear}-${bornAtMonth}-${bornAtDay}`;
-
   console.group("Wallet data");
   console.log("EMAIL => ", email);
-  console.log("BORN AT => ", bornAt);
+  console.log("TOKEN => ", token);
   console.groupEnd();
 
-  for (const value of [email, bornAtDay, bornAtMonth, bornAtYear]) {
+  for (const value of [email, token]) {
     if (value === "") {
       return {};
     }
   }
 
-  const userWallet = VocdoniSDKClient.generateWalletFromData([email, bornAt]);
+  const userWallet = VocdoniSDKClient.generateWalletFromData([email, token]);
 
   return userWallet;
 }

--- a/app/packs/src/decidim/vocdoni/voter/new-vote.js
+++ b/app/packs/src/decidim/vocdoni/voter/new-vote.js
@@ -4,7 +4,7 @@ import { ElectionStatus, VocdoniSDKClient } from "@vocdoni/sdk";
 import VoteQuestionsComponent from "./vote_questions.component";
 import VoteComponent from "./setup-vote";
 import PreviewVoteComponent from "./setup-preview";
-import { walletFromLoginForm, checkIfWalletIsInCensus } from "./census-utils";
+import { walletFromLoginForm } from "./census-utils";
 
 /*
  * Mount the VoteComponent object and bind the events to the UI
@@ -144,12 +144,20 @@ $(() => {
         return;
       }
 
-      const isInCensus = await checkIfWalletIsInCensus(env, wallet, electionUniqueId);
+      const client = new VocdoniSDKClient({ env, wallet })
+      client.setElectionId(electionUniqueId);
+      const isInCensus = await client.isInCensus();
       console.log("IS IN CENSUS => ", isInCensus);
 
       if (!isInCensus) {
         showLoginErrorMessage();
         return;
+      }
+
+      const hasAlreadyVoted = await client.hasAlreadyVoted();
+      if (hasAlreadyVoted) {
+        console.log("ALREADY VOTED");
+        $("#step-0").find(".js-already_voted").removeClass("hide");
       }
 
       console.log("OK!! Wallet is in census");

--- a/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
@@ -76,6 +76,14 @@
     }
   }
 
+  &__login{
+    width: 20rem;
+
+    @include breakpoint(large){
+      width: 30rem;
+    }
+  }
+
   &__check{
     cursor: pointer;
     display: flex;

--- a/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
+++ b/app/packs/stylesheets/decidim/vocdoni/focus/_evote.scss
@@ -337,7 +337,7 @@
   }
 
   &__preview-perc{
-    width: 2rem;
+    width: 3rem;
     text-align: right;
     font-weight: bold;
   }

--- a/app/views/decidim/vocdoni/admin/census/_generate_form.html.erb
+++ b/app/views/decidim/vocdoni/admin/census/_generate_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.fields_for "credentials[]", credential do |credential_form| %>
         <%= content_tag "li", data: { credential: credential.id } do %>
           <%= credential_form.text_field :email, class: "credential_email" %>
-          <%= credential_form.text_field :born_at, class: "credential_born_at" %>
+          <%= credential_form.text_field :token, class: "credential_token" %>
           <%= credential_form.text_field :wallet_address, class: "credential_wallet_address" %>
         <% end %>
       <% end %>

--- a/app/views/decidim/vocdoni/admin/census/_upload_form.html.erb
+++ b/app/views/decidim/vocdoni/admin/census/_upload_form.html.erb
@@ -1,8 +1,8 @@
 <p><%= t("decidim.vocdoni.admin.census.new.info") %></p>
 <pre class="code-block">
-email;born_at
-user@example.org;1984-01-25
-user2@example.org;2000-12-15</pre>
+email;token
+user@example.org;123456
+user2@example.org;ABCXYZ</pre>
 <%= decidim_form_for form, url: election_census_path(election), multipart: true do |form| %>
   <%= label_tag :file, t("new.file", scope: "decidim.vocdoni.admin.census") %>
   <%= form.file_field :file, required: true %>

--- a/app/views/decidim/vocdoni/votes/_login.html.erb
+++ b/app/views/decidim/vocdoni/votes/_login.html.erb
@@ -10,7 +10,7 @@
       <div class="evote__grid">
         <%= decidim_form_for(@form, url: "#", html: { class: "form", autocomplete: "off" }) do |f| %>
           <div class="row mt-sm">
-            <div class="columns medium-centered large-12">
+            <div class="columns medium-centered evote__login">
               <p class="text-center"><strong><%= t(".form_title") %></strong></p>
               <div class="card">
                 <div class="card__content">

--- a/app/views/decidim/vocdoni/votes/_login.html.erb
+++ b/app/views/decidim/vocdoni/votes/_login.html.erb
@@ -10,7 +10,7 @@
       <div class="evote__grid">
         <%= decidim_form_for(@form, url: "#", html: { class: "form", autocomplete: "off" }) do |f| %>
           <div class="row mt-sm">
-            <div class="columns medium-centered large-8">
+            <div class="columns medium-centered large-12">
               <p class="text-center"><strong><%= t(".form_title") %></strong></p>
               <div class="card">
                 <div class="card__content">

--- a/app/views/decidim/vocdoni/votes/_login_fields.html.erb
+++ b/app/views/decidim/vocdoni/votes/_login_fields.html.erb
@@ -1,20 +1,6 @@
 <div>
   <%= f.text_field :email, label: t(".email"), placeholder: t(".email_placeholder") %>
 </div>
-<fieldset>
-  <legend><%= t(".born_at") %></legend>
-  <div class="row">
-    <div class="columns small-4">
-      <%= f.text_field :day, placeholder: t(".day_placeholder"), label: t(".day"), "data-autojump" => true, "data-max-length" => 2,
-        "data-jump-next" => "#login_month" %>
-    </div>
-    <div class="columns small-4">
-      <%= f.text_field :month, placeholder: t(".month_placeholder"), label: t(".month"), "data-autojump" => true, "data-max-length" => 2,
-        "data-jump-prev" => "#login_day", "data-jump-next" => "#login_year" %>
-    </div>
-    <div class="columns small-4">
-      <%= f.text_field :year, placeholder: t(".year_placeholder"), label: t(".year"), "data-autojump" => true, "data-max-length" => 4,
-        "data-jump-prev" => "#login_month" %>
-    </div>
-  </div>
-</fieldset>
+<div>
+  <%= f.text_field :token, label: t(".token"), placeholder: t(".token_placeholder") %>
+</div>

--- a/app/views/decidim/vocdoni/votes/new.html.erb
+++ b/app/views/decidim/vocdoni/votes/new.html.erb
@@ -24,6 +24,10 @@
         </div>
       </div>
 
+      <% if step_index == 0 %>
+        <div class="callout warning hide js-already_voted"><%= t(".already_voted") %></div>
+      <% end %>
+
       <div class="focus__content evote">
         <div class="row">
           <%= render(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -406,6 +406,8 @@ en:
         modal:
           close: Close
         new:
+          already_voted: You have already voted on this election. You can vote again.
+            The previous vote will be overwritten.
           more_information: More information
           preview_alert: This is a preview of the voting booth.
           question_steps: Question %{current_step} of %{total_steps}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,15 +397,10 @@ en:
           form_title: Enter your data
           title: Verify your identity
         login_fields:
-          born_at: Date of birth
-          day: Day
-          day_placeholder: DD
           email: Email
           email_placeholder: user@example.org
-          month: Month
-          month_placeholder: MM
-          year: Year
-          year_placeholder: YYYY
+          token: Token
+          token_placeholder: 123456
         messages:
           not_allowed: You are not allowed to vote on this election at this moment.
         modal:

--- a/db/migrate/20230314115532_change_census_fields_on_decidim_vocodni_voters.rb
+++ b/db/migrate/20230314115532_change_census_fields_on_decidim_vocodni_voters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeCensusFieldsOnDecidimVocodniVoters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_vocdoni_voters, :token, :string
+    remove_column :decidim_vocdoni_voters, :born_at, :date
+  end
+end

--- a/lib/decidim/vocdoni/test/factories.rb
+++ b/lib/decidim/vocdoni/test/factories.rb
@@ -198,7 +198,7 @@ FactoryBot.define do
 
   factory :vocdoni_voter, class: "Decidim::Vocdoni::Voter" do
     email { generate(:email) }
-    born_at { Faker::Date.between(from: 110.years.ago, to: 16.years.ago) }
+    token { Faker::String.random(length: 4) }
     association :election, factory: :vocdoni_election
 
     trait :with_credentials do

--- a/spec/assets/valid-census.csv
+++ b/spec/assets/valid-census.csv
@@ -1,2 +1,2 @@
-email;born_at
-example@example.org;2000-01-01
+email;token
+example@example.org;123456

--- a/spec/models/decidim/vocdoni/answer_spec.rb
+++ b/spec/models/decidim/vocdoni/answer_spec.rb
@@ -10,13 +10,28 @@ describe Decidim::Vocdoni::Answer do
   include_examples "resourceable"
 
   describe "#votes_percentage" do
-    subject(:answer) { create(:vocdoni_election_answer, question: question, votes: 5) }
+    subject(:answer1) { create(:vocdoni_election_answer, question: question, votes: 5) }
 
     let(:question) { create(:vocdoni_question) }
-    let!(:other_answer) { create(:vocdoni_election_answer, question: question, votes: 10) }
+    let!(:answer2) { create(:vocdoni_election_answer, question: question, votes: 10) }
 
     it "returns a percentage" do
-      expect(subject.votes_percentage).to eq(33)
+      expect(subject.votes_percentage).to eq(33.33)
+    end
+
+    it "sums to 100" do
+      expect(subject.votes_percentage + answer2.votes_percentage).to eq(100)
+    end
+
+    context "when there are multiple answers" do
+      let!(:answer3) { create(:vocdoni_election_answer, question: question, votes: 11) }
+      let!(:answer4) { create(:vocdoni_election_answer, question: question, votes: 22) }
+      let!(:answer5) { create(:vocdoni_election_answer, question: question, votes: 33) }
+      let!(:answer6) { create(:vocdoni_election_answer, question: question, votes: 1) }
+
+      it "sums to 100" do
+        expect(subject.question.answers.map(&:votes_percentage).sum).to eq(100)
+      end
     end
   end
 end

--- a/spec/models/decidim/vocdoni/voter_spec.rb
+++ b/spec/models/decidim/vocdoni/voter_spec.rb
@@ -10,8 +10,8 @@ describe Decidim::Vocdoni::Voter do
   describe ".insert_all" do
     let(:values) do
       [
-        ["user1@example.org", "2000-01-01"],
-        ["user2@example.org", "2001-01-01"]
+        ["user1@example.org", "123456"],
+        ["user2@example.org", "abcxyz"]
       ]
     end
 
@@ -24,24 +24,36 @@ describe Decidim::Vocdoni::Voter do
     it "creates the voters" do
       voter1 = Decidim::Vocdoni::Voter.first
       expect(voter1.email).to eq "user1@example.org"
-      expect(voter1.born_at).to eq Date.parse("2000-01-01")
+      expect(voter1.token).to eq "123456"
       expect(voter1.election).to eq election
 
       voter2 = Decidim::Vocdoni::Voter.second
       expect(voter2.email).to eq "user2@example.org"
-      expect(voter2.born_at).to eq Date.parse("2001-01-01")
+      expect(voter2.token).to eq "abcxyz"
       expect(voter2.election).to eq election
     end
 
     context "when the email isn't lowercase" do
       let(:values) do
         [
-          ["USER1@example.org", "2000-01-01"]
+          ["USER1@example.org", "123456"]
         ]
       end
 
       it "is normalized" do
         expect(Decidim::Vocdoni::Voter.first.email).to eq("user1@example.org")
+      end
+    end
+
+    context "when the token isn't lowercase" do
+      let(:values) do
+        [
+          ["USER1@example.org", "ABCXYZ"]
+        ]
+      end
+
+      it "is normalized" do
+        expect(Decidim::Vocdoni::Voter.first.token).to eq("abcxyz")
       end
     end
   end

--- a/spec/shared/vote_examples.rb
+++ b/spec/shared/vote_examples.rb
@@ -23,7 +23,7 @@ shared_examples "allows admins to preview the voting booth" do
     click_link "Preview"
   end
 
-  it { uses_the_voting_booth({ email: user.email, born_at: "2000-01-01" }) }
+  it { uses_the_voting_booth({ email: user.email, token: "123456" }) }
 
   it "shows the preview alert" do
     expect(page).to have_content("This is a preview of the voting booth.")
@@ -92,13 +92,9 @@ def uses_the_voting_booth(census_data)
 end
 
 def login_step(census_data)
-  year, month, day = census_data.fetch(:born_at).split("-")
-
   within "#login" do
     fill_in :login_email, with: census_data.fetch(:email)
-    fill_in :login_day, with: day
-    fill_in :login_month, with: month
-    fill_in :login_year, with: year
+    fill_in :login_token, with: census_data.fetch(:token)
 
     click_button "Access"
   end

--- a/spec/system/decidim/admin/admin_manages_census_spec.rb
+++ b/spec/system/decidim/admin/admin_manages_census_spec.rb
@@ -25,11 +25,11 @@ describe "Admin manages census", :slow, type: :system do
 
   context "when there's already a census" do
     context "without the credentials" do
-      let!(:voter1) { create(:vocdoni_voter, election: election, born_at: "1923-01-01", email: "user_1@example.org") }
-      let!(:voter2) { create(:vocdoni_voter, election: election, born_at: "1977-02-23", email: "user_2@example.org") }
-      let!(:voter3) { create(:vocdoni_voter, election: election, born_at: "2000-02-23", email: "user_3@example.org") }
-      let!(:voter4) { create(:vocdoni_voter, election: election, born_at: "1992-02-23", email: "user_4@example.org") }
-      let!(:voter5) { create(:vocdoni_voter, election: election, born_at: "1954-02-23", email: "user_5@example.org") }
+      let!(:voter1) { create(:vocdoni_voter, election: election, token: "123456", email: "user_1@example.org") }
+      let!(:voter2) { create(:vocdoni_voter, election: election, token: "123abc", email: "user_2@example.org") }
+      let!(:voter3) { create(:vocdoni_voter, election: election, token: "123abc", email: "user_3@example.org") }
+      let!(:voter4) { create(:vocdoni_voter, election: election, token: "abcxyz", email: "user_4@example.org") }
+      let!(:voter5) { create(:vocdoni_voter, election: election, token: "123abc", email: "user_5@example.org") }
 
       it "generates the credentials" do
         visit_census_page
@@ -41,11 +41,11 @@ describe "Admin manages census", :slow, type: :system do
         click_button "Confirm the census data"
 
         expect(page).to have_content("The census data is uploaded and confirmed")
-        expect(voter1.reload.wallet_address).to eq("0x50a688dbB767bD3ebd93022B87B2c19cE936bd93")
-        expect(voter2.reload.wallet_address).to eq("0xA7e77F2706e6981002c15B5E8d441fBC8EA0fC9E")
-        expect(voter3.reload.wallet_address).to eq("0xd2d6C90A4f4daed530D9b0B7Aae3271c73610AA7")
-        expect(voter4.reload.wallet_address).to eq("0x8a186ec407591ef7c5D000C81D99f7E174648a27")
-        expect(voter5.reload.wallet_address).to eq("0x75bA570b7135216f14B9A4C77558159793367fFb")
+        expect(voter1.reload.wallet_address).to eq("0xFEA59AF4dD69C285f39CC6836DA2664f36A47A71")
+        expect(voter2.reload.wallet_address).to eq("0xA0A46c789F1D86a0AA04Cd18E7965C726864B991")
+        expect(voter3.reload.wallet_address).to eq("0x1A4d5529E04803054fC0338eA07083FD977cD115")
+        expect(voter4.reload.wallet_address).to eq("0xBc8dB7502067bFCc44ccCA105dD4cdfabB8DDDfb")
+        expect(voter5.reload.wallet_address).to eq("0x183f5bC91423354F7351dFC4a877a8AC75910CA1")
       end
 
       describe "and we want to delete it" do

--- a/spec/system/decidim/preview_vote_online_spec.rb
+++ b/spec/system/decidim/preview_vote_online_spec.rb
@@ -26,7 +26,7 @@ describe "Preview vote online in an election", type: :system do
 
       expect(page).to have_content("This is a preview of the voting booth.")
 
-      uses_the_voting_booth({ email: admin.email, born_at: "2000-01-01" })
+      uses_the_voting_booth({ email: admin.email, token: "123456" })
       page.find("a.focus__exit").click
 
       expect(page).to have_current_path router.election_path(id: election.id)
@@ -43,7 +43,7 @@ describe "Preview vote online in an election", type: :system do
         visit_component
         click_link translated(election.title)
         click_link "Preview"
-        login_step({ email: admin.email, born_at: "2000-01-01" })
+        login_step({ email: admin.email, token: "123456" })
         expect(page).to have_content("MORE INFORMATION")
       end
     end


### PR DESCRIPTION
This PR brings 3 changes:

1. We change the name and type of one of the Census fields: as date of birth (born_at) isn't a data that we have for the pilot that we'll do in 10 days we'll use "tokens" (strings of texts). By design we don't validate them (as they could be any string with any length) 
2. We allow the vote overwrite and show a callout message when that's the case

## Testing

### Census with token

1. Create a new census file with the header "email;token" 
3. The token can be any string 
4. Do the whole process (specially setup and voting, as they're the tasks where the census is used)

### Vote overwrite

1. Vote once
2. Vote again
3. See callout