### PR TITLE
Add JavaScript tests npm command and GitHub workflow

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -1,0 +1,42 @@
+name: "[CI] JavaScript Tests"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CI: "true"
+  NODE_VERSION: 16.9.1
+
+jobs:
+  test-report:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get npm cache directory path
+        id: npm-cache-dir-path
+        run: echo "::set-output name=dir::$(npm get cache)-vocdoni"
+
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - run: npm ci
+      - run: npm run test
+        name: Node test
+        env:
+          CODECOV: 1

--- a/.github/workflows/test-rails.yml
+++ b/.github/workflows/test-rails.yml
@@ -1,4 +1,4 @@
-name: "[CI] Tests"
+name: "[CI] Ruby on Rails Tests"
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ can add these environment variables to the root directory of the project in a
 file named `.rbenv-vars`. In this case, you can omit defining these in the
 commands shown above.
 
+We also have some tests for the Javascript code. To run them, you can use the
+following commands:
+
+```bash
+npm ci
+npm run test
+```
+
 ### Test code coverage
 
 Code coverage report is generated automatically after running the test suite, in a folder

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "ENV=dev WALLET=random node node-wrapper/test_census.mjs",
     "lint": "eslint -c .eslintrc.json --ext .js --ext .mjs app/packs/ node-wrapper/",
     "lint-fix": "eslint -c .eslintrc.json --ext .js --ext .mjs app/packs/ node-wrapper/ --fix",
     "stylelint": "stylelint **/*.scss",


### PR DESCRIPTION
Comes from this [comment](https://github.com/decidim-vocdoni/decidim-module-vocdoni/pull/71#discussion_r1515746916)

This PR adds an npm command for the execution of the JavaScript tests. 

It also adds the GitHub workflow configuration to catch regressions in these tests. 
